### PR TITLE
refactor: 컴포넌트에서 UI 로직을 페이지 커스텀훅으로 분리(2)

### DIFF
--- a/frontend/src/components/ChallengeItem/index.tsx
+++ b/frontend/src/components/ChallengeItem/index.tsx
@@ -1,3 +1,5 @@
+import { queryKeys } from 'apis/constants';
+import { useQueryClient } from 'react-query';
 import { Link, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { getEmoji } from 'utils/emoji';
@@ -15,13 +17,15 @@ export const ChallengeItem = ({
   challengeName,
   challengerCount,
   isInProgress,
-  challengeListRefetch,
 }: ChallengeItemProps) => {
   const themeContext = useThemeContext();
+  const queryClient = useQueryClient();
 
   const { joinChallenge } = usePostJoinChallenge({
     challengeId: Number(challengeId),
-    successCallback: challengeListRefetch,
+    successCallback: () => {
+      queryClient.invalidateQueries(queryKeys.getAllChallenges);
+    },
   });
 
   const navigate = useNavigate();

--- a/frontend/src/components/ChallengeItem/type.ts
+++ b/frontend/src/components/ChallengeItem/type.ts
@@ -3,5 +3,4 @@ export interface ChallengeItemProps {
   challengeName: string;
   challengerCount: number;
   isInProgress: boolean;
-  challengeListRefetch: () => void;
 }

--- a/frontend/src/components/ChallengeList/ChallengeList.stories.tsx
+++ b/frontend/src/components/ChallengeList/ChallengeList.stories.tsx
@@ -1,8 +1,18 @@
+import { challengeData } from 'mocks/data';
+
 import { ChallengeList } from 'components';
+import { ChallengeListProps } from 'components/ChallengeList/type';
 
 export default {
   title: 'Components/ChallengeList',
   component: ChallengeList,
 };
 
-export const DefaultChallengeList = () => <ChallengeList />;
+export const DefaultChallengeList = (args: ChallengeListProps) => (
+  <ChallengeList {...args} />
+);
+
+DefaultChallengeList.args = {
+  challengeListData: challengeData,
+  challengeListRefetch: () => {},
+};

--- a/frontend/src/components/ChallengeList/ChallengeList.stories.tsx
+++ b/frontend/src/components/ChallengeList/ChallengeList.stories.tsx
@@ -14,5 +14,4 @@ export const DefaultChallengeList = (args: ChallengeListProps) => (
 
 DefaultChallengeList.args = {
   challengeListData: challengeData,
-  challengeListRefetch: () => {},
 };

--- a/frontend/src/components/ChallengeList/index.tsx
+++ b/frontend/src/components/ChallengeList/index.tsx
@@ -1,4 +1,4 @@
-import { FlexBox, ChallengeItem, LoadingSpinner } from 'components';
+import { FlexBox, ChallengeItem } from 'components';
 import { ChallengeListProps } from 'components/ChallengeList/type';
 
 export const ChallengeList = ({
@@ -6,13 +6,9 @@ export const ChallengeList = ({
   challengeListData,
   challengeListRefetch,
 }: ChallengeListProps) => {
-  if (challengeListData === null) {
-    return <LoadingSpinner />;
-  }
-
   return (
     <FlexBox as="ul" flexDirection="column" gap="27px">
-      {challengeListData.map((challengeInfo, challengeIndex) => (
+      {challengeListData?.map((challengeInfo, challengeIndex) => (
         <li
           key={challengeInfo.challengeId}
           ref={challengeIndex === challengeListData.length - 1 ? targetRef : undefined}

--- a/frontend/src/components/ChallengeList/index.tsx
+++ b/frontend/src/components/ChallengeList/index.tsx
@@ -1,52 +1,25 @@
-import { useGetAllChallenges } from 'apis';
-import { useRef, RefObject, useMemo } from 'react';
-
-import useIntersect from 'hooks/useIntersect';
-
 import { FlexBox, ChallengeItem, LoadingSpinner } from 'components';
-import { ChallengeInfo } from 'components/ChallengeList/type';
+import { ChallengeListProps } from 'components/ChallengeList/type';
 
-export const ChallengeList = () => {
-  const { isFetching, data, refetch, hasNextPage, fetchNextPage } = useGetAllChallenges({
-    refetchOnWindowFocus: false,
-  });
-
-  const rootRef = useRef() as RefObject<HTMLUListElement>;
-
-  const options = useMemo(() => ({ root: rootRef.current, threshold: 0.5 }), []);
-  const targetRef = useIntersect<HTMLLIElement>((entry, observer) => {
-    if (hasNextPage) {
-      fetchNextPage();
-    }
-    observer.unobserve(entry.target);
-  }, options);
-
-  if (typeof data === 'undefined') {
+export const ChallengeList = ({
+  targetRef,
+  challengeListData,
+  challengeListRefetch,
+}: ChallengeListProps) => {
+  if (challengeListData === null) {
     return <LoadingSpinner />;
   }
 
   return (
-    <FlexBox as="ul" ref={rootRef} flexDirection="column" gap="27px">
-      {data.pages.map((page, pageIndex) => {
-        if (typeof page === 'undefined' || typeof page.data === 'undefined') {
-          return [];
-        }
-
-        return page.data.map((challengeInfo: ChallengeInfo, challengeIndex: number) => (
-          <li
-            key={challengeInfo.challengeId}
-            ref={
-              pageIndex === data.pages.length - 1 &&
-              challengeIndex === page.data.length - 1
-                ? targetRef
-                : undefined
-            }
-          >
-            <ChallengeItem {...challengeInfo} challengeListRefetch={refetch} />
-          </li>
-        ));
-      })}
-      {isFetching && <LoadingSpinner />}
+    <FlexBox as="ul" flexDirection="column" gap="27px">
+      {challengeListData.map((challengeInfo, challengeIndex) => (
+        <li
+          key={challengeInfo.challengeId}
+          ref={challengeIndex === challengeListData.length - 1 ? targetRef : undefined}
+        >
+          <ChallengeItem {...challengeInfo} challengeListRefetch={challengeListRefetch} />
+        </li>
+      ))}
     </FlexBox>
   );
 };

--- a/frontend/src/components/ChallengeList/index.tsx
+++ b/frontend/src/components/ChallengeList/index.tsx
@@ -1,11 +1,7 @@
 import { FlexBox, ChallengeItem } from 'components';
 import { ChallengeListProps } from 'components/ChallengeList/type';
 
-export const ChallengeList = ({
-  targetRef,
-  challengeListData,
-  challengeListRefetch,
-}: ChallengeListProps) => {
+export const ChallengeList = ({ targetRef, challengeListData }: ChallengeListProps) => {
   return (
     <FlexBox as="ul" flexDirection="column" gap="27px">
       {challengeListData?.map((challengeInfo, challengeIndex) => (
@@ -13,7 +9,7 @@ export const ChallengeList = ({
           key={challengeInfo.challengeId}
           ref={challengeIndex === challengeListData.length - 1 ? targetRef : undefined}
         >
-          <ChallengeItem {...challengeInfo} challengeListRefetch={challengeListRefetch} />
+          <ChallengeItem {...challengeInfo} />
         </li>
       ))}
     </FlexBox>

--- a/frontend/src/components/ChallengeList/type.ts
+++ b/frontend/src/components/ChallengeList/type.ts
@@ -1,3 +1,11 @@
+import { RefObject } from 'react';
+
 import { ChallengeItemProps } from 'components/ChallengeItem/type';
 
 export type ChallengeInfo = Omit<ChallengeItemProps, 'challengeListRefetch'>;
+
+export interface ChallengeListProps {
+  targetRef?: RefObject<HTMLLIElement>;
+  challengeListData: ChallengeInfo[] | null;
+  challengeListRefetch: () => void;
+}

--- a/frontend/src/components/ChallengeList/type.ts
+++ b/frontend/src/components/ChallengeList/type.ts
@@ -6,6 +6,6 @@ export type ChallengeInfo = Omit<ChallengeItemProps, 'challengeListRefetch'>;
 
 export interface ChallengeListProps {
   targetRef?: RefObject<HTMLLIElement>;
-  challengeListData: ChallengeInfo[] | null;
+  challengeListData?: ChallengeInfo[];
   challengeListRefetch: () => void;
 }

--- a/frontend/src/components/ChallengeList/type.ts
+++ b/frontend/src/components/ChallengeList/type.ts
@@ -2,10 +2,7 @@ import { RefObject } from 'react';
 
 import { ChallengeItemProps } from 'components/ChallengeItem/type';
 
-export type ChallengeInfo = Omit<ChallengeItemProps, 'challengeListRefetch'>;
-
 export interface ChallengeListProps {
   targetRef?: RefObject<HTMLLIElement>;
-  challengeListData?: ChallengeInfo[];
-  challengeListRefetch: () => void;
+  challengeListData?: ChallengeItemProps[];
 }

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -1,32 +1,17 @@
-import { useGetLinkGoogle } from 'apis';
 import { FaBell } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
-import { useRecoilState } from 'recoil';
-import { isLoginState } from 'recoil/auth/atoms';
-import { isDarkState } from 'recoil/darkMode/atoms';
 import styled, { css } from 'styled-components';
-
-import useThemeContext from 'hooks/useThemeContext';
 
 import { Logo, FlexBox, Button, ToggleButton } from 'components';
 import { HeaderProps } from 'components/Header/type';
+import { useHeader } from 'components/Header/useHeader';
 
 import { Z_INDEX } from 'constants/css';
 import { CLIENT_PATH } from 'constants/path';
 
 export const Header = ({ bgColor }: HeaderProps) => {
-  const [isDark, setIsDark] = useRecoilState(isDarkState);
-
-  const isLogin = useRecoilValue(isLoginState);
-  const themeContext = useThemeContext();
-
-  const { refetch: redirectGoogleLoginLink } = useGetLinkGoogle();
-
-  const handleDarkToggle = () => {
-    localStorage.setItem('isDark', JSON.stringify(!isDark));
-    setIsDark((prev) => !prev);
-  };
+  const { themeContext, isDark, isLogin, handleDarkToggle, handleLoginButton } =
+    useHeader();
 
   return (
     <Wrapper bgColor={bgColor} justifyContent="space-between" alignItems="center">
@@ -38,7 +23,7 @@ export const Header = ({ bgColor }: HeaderProps) => {
         {isLogin ? (
           <FaBell size={23} color={themeContext.primary} />
         ) : (
-          <Button size="small" onClick={() => redirectGoogleLoginLink()}>
+          <Button size="small" onClick={handleLoginButton}>
             로그인
           </Button>
         )}

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -2,6 +2,8 @@ import { FaBell } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
+import useThemeContext from 'hooks/useThemeContext';
+
 import { Logo, FlexBox, Button, ToggleButton } from 'components';
 import { HeaderProps } from 'components/Header/type';
 import { useHeader } from 'components/Header/useHeader';
@@ -10,8 +12,8 @@ import { Z_INDEX } from 'constants/css';
 import { CLIENT_PATH } from 'constants/path';
 
 export const Header = ({ bgColor }: HeaderProps) => {
-  const { themeContext, isDark, isLogin, handleDarkToggle, handleLoginButton } =
-    useHeader();
+  const themeContext = useThemeContext();
+  const { isDark, isLogin, handleDarkToggle, handleLoginButton } = useHeader();
 
   return (
     <Wrapper bgColor={bgColor} justifyContent="space-between" alignItems="center">

--- a/frontend/src/components/Header/useHeader.ts
+++ b/frontend/src/components/Header/useHeader.ts
@@ -3,13 +3,10 @@ import { useRecoilState, useRecoilValue } from 'recoil';
 import { isLoginState } from 'recoil/auth/atoms';
 import { isDarkState } from 'recoil/darkMode/atoms';
 
-import useThemeContext from 'hooks/useThemeContext';
-
 export const useHeader = () => {
   const [isDark, setIsDark] = useRecoilState(isDarkState);
 
   const isLogin = useRecoilValue(isLoginState);
-  const themeContext = useThemeContext();
 
   const { refetch: redirectGoogleLoginLink } = useGetLinkGoogle();
 
@@ -23,7 +20,6 @@ export const useHeader = () => {
   };
 
   return {
-    themeContext,
     isDark,
     isLogin,
     handleDarkToggle,

--- a/frontend/src/components/Header/useHeader.ts
+++ b/frontend/src/components/Header/useHeader.ts
@@ -1,0 +1,32 @@
+import { useGetLinkGoogle } from 'apis';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { isLoginState } from 'recoil/auth/atoms';
+import { isDarkState } from 'recoil/darkMode/atoms';
+
+import useThemeContext from 'hooks/useThemeContext';
+
+export const useHeader = () => {
+  const [isDark, setIsDark] = useRecoilState(isDarkState);
+
+  const isLogin = useRecoilValue(isLoginState);
+  const themeContext = useThemeContext();
+
+  const { refetch: redirectGoogleLoginLink } = useGetLinkGoogle();
+
+  const handleDarkToggle = () => {
+    localStorage.setItem('isDark', JSON.stringify(!isDark));
+    setIsDark((prev) => !prev);
+  };
+
+  const handleLoginButton = () => {
+    redirectGoogleLoginLink();
+  };
+
+  return {
+    themeContext,
+    isDark,
+    isLogin,
+    handleDarkToggle,
+    handleLoginButton,
+  };
+};

--- a/frontend/src/components/InfiniteScroll/index.tsx
+++ b/frontend/src/components/InfiniteScroll/index.tsx
@@ -1,0 +1,34 @@
+import { InfiniteScrollProps } from './type';
+import { RefObject, useMemo, useRef } from 'react';
+
+import useIntersect from 'hooks/useIntersect';
+
+import { FlexBox } from 'components';
+
+export const InfiniteScroll = ({
+  children,
+  loadMore,
+  hasMore,
+  isFetching,
+  loader,
+  threshold = 0.5,
+}: InfiniteScrollProps) => {
+  const rootRef = useRef() as RefObject<HTMLDivElement>;
+
+  const options = useMemo(() => ({ root: rootRef.current, threshold }), []);
+
+  const targetRef = useIntersect<HTMLDivElement>((entry, observer) => {
+    if (hasMore) {
+      loadMore();
+    }
+    observer.unobserve(entry.target);
+  }, options);
+
+  return (
+    <FlexBox ref={rootRef} flexDirection="column">
+      {children}
+      <div ref={targetRef} />
+      {isFetching && loader}
+    </FlexBox>
+  );
+};

--- a/frontend/src/components/InfiniteScroll/type.ts
+++ b/frontend/src/components/InfiniteScroll/type.ts
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react';
+
+export interface InfiniteScrollProps {
+  children: ReactNode;
+  loadMore: () => void;
+  hasMore?: boolean;
+  isFetching: boolean;
+  loader?: ReactNode;
+  threshold?: number;
+}

--- a/frontend/src/components/Input/index.tsx
+++ b/frontend/src/components/Input/index.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
 import styled, { css } from 'styled-components';
 
 import { InputProps, InputContainerProps } from 'components/Input/type';
+import { useInput } from 'components/Input/useInput';
 import { ValidationMessage } from 'components/ValidationMessage';
 
 export const Input = ({
@@ -14,7 +14,7 @@ export const Input = ({
   message,
   disabled,
 }: InputProps) => {
-  const [isFocus, setIsFocus] = useState(false);
+  const { isFocus, handleFocus, handleBlur } = useInput();
 
   return (
     <Wrapper>
@@ -26,8 +26,8 @@ export const Input = ({
           placeholder={placeholder}
           value={value}
           onChange={onChange}
-          onFocus={() => setIsFocus(true)}
-          onBlur={() => setIsFocus(false)}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
           disabled={disabled}
         />
       </InputWrapper>

--- a/frontend/src/components/Input/useInput.ts
+++ b/frontend/src/components/Input/useInput.ts
@@ -1,0 +1,19 @@
+import { useState } from 'react';
+
+export const useInput = () => {
+  const [isFocus, setIsFocus] = useState(false);
+
+  const handleFocus = () => {
+    setIsFocus(true);
+  };
+
+  const handleBlur = () => {
+    setIsFocus(false);
+  };
+
+  return {
+    isFocus,
+    handleFocus,
+    handleBlur,
+  };
+};

--- a/frontend/src/components/LandingNavigation/index.tsx
+++ b/frontend/src/components/LandingNavigation/index.tsx
@@ -1,21 +1,14 @@
 import { Navigate } from 'react-router-dom';
 
+import { LandingNavigationProps } from 'components/LandingNavigation/type';
 import { LoadingSpinner } from 'components/LoadingSpinner';
 
 import { CLIENT_PATH } from 'constants/path';
 
-export const LandingNavigation = ({
-  isLogin,
-  isLoading,
-}: {
-  isLogin: boolean;
-  isLoading: boolean;
-}) => {
+export const LandingNavigation = ({ isLogin, isLoading }: LandingNavigationProps) => {
   if (isLoading) return <LoadingSpinner />;
 
-  return isLogin ? (
-    <Navigate to={CLIENT_PATH.CERT} />
-  ) : (
-    <Navigate to={CLIENT_PATH.HOME} />
-  );
+  if (isLogin) return <Navigate to={CLIENT_PATH.CERT} />;
+
+  return <Navigate to={CLIENT_PATH.HOME} />;
 };

--- a/frontend/src/components/LandingNavigation/type.ts
+++ b/frontend/src/components/LandingNavigation/type.ts
@@ -1,0 +1,4 @@
+export interface LandingNavigationProps {
+  isLogin: boolean;
+  isLoading: boolean;
+}

--- a/frontend/src/components/LoadingButton/index.tsx
+++ b/frontend/src/components/LoadingButton/index.tsx
@@ -13,9 +13,9 @@ export const LoadingButton = ({
   loadingText,
   successText,
 }: LoadingButtonProps) => {
-  return (
-    <Element size="large" disabled={isDisabled || isLoading || isSuccess}>
-      {isLoading ? (
+  if (isLoading) {
+    return (
+      <Element size="large" disabled={true}>
         <FlexBox
           flexDirection="row"
           gap="1rem"
@@ -25,11 +25,21 @@ export const LoadingButton = ({
           {loadingText}
           <LoadingDots />
         </FlexBox>
-      ) : isSuccess ? (
-        successText
-      ) : (
-        defaultText
-      )}
+      </Element>
+    );
+  }
+
+  if (isSuccess) {
+    return (
+      <Element size="large" disabled={true}>
+        {successText}
+      </Element>
+    );
+  }
+
+  return (
+    <Element size="large" disabled={isDisabled}>
+      {defaultText}
     </Element>
   );
 };

--- a/frontend/src/components/LoadingSpinner/index.tsx
+++ b/frontend/src/components/LoadingSpinner/index.tsx
@@ -1,12 +1,14 @@
 import styled, { keyframes } from 'styled-components';
 
-const LoadingBox = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  gap: 50px;
-`;
+import { FlexBox } from 'components/';
+
+export const LoadingSpinner = () => {
+  return (
+    <FlexBox flexDirection="column" justifyContent="center" alignItems="center">
+      <Spinner />
+    </FlexBox>
+  );
+};
 
 const spin = keyframes`
   to { -webkit-transform: rotate(360deg); }
@@ -21,11 +23,3 @@ const Spinner = styled.div`
   animation: ${spin} 1s ease-in-out infinite;
   -webkit-animation: ${spin} 1s ease-in-out infinite;
 `;
-
-export const LoadingSpinner = () => {
-  return (
-    <LoadingBox>
-      <Spinner />
-    </LoadingBox>
-  );
-};

--- a/frontend/src/components/Logo/index.tsx
+++ b/frontend/src/components/Logo/index.tsx
@@ -3,14 +3,15 @@ import styled from 'styled-components';
 
 import { LogoProps } from 'components/Logo/type';
 
+const svg = {
+  start: { pathLength: 0, fill: 'rgba(255, 255, 255, 0)' },
+  end: {
+    fill: '#7B61FF',
+    pathLength: 1,
+  },
+};
+
 export const Logo = ({ width, color, isAnimated }: LogoProps) => {
-  const svg = {
-    start: { pathLength: 0, fill: 'rgba(255, 255, 255, 0)' },
-    end: {
-      fill: '#7B61FF',
-      pathLength: 1,
-    },
-  };
   return (
     <Svg width={width} viewBox="0 0 156 44" xmlns="http://www.w3.org/2000/svg">
       {isAnimated ? (

--- a/frontend/src/components/Navbar/index.tsx
+++ b/frontend/src/components/Navbar/index.tsx
@@ -5,30 +5,15 @@ import Search from 'assets/search.svg';
 import { Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
-import useMatchPath from 'hooks/useMatchPath';
-import useThemeContext from 'hooks/useThemeContext';
-
 import { Text, FlexBox } from 'components';
 import { NavLinkProps } from 'components/Navbar/type';
+import { useNavBar } from 'components/Navbar/useNavBar';
 
 import { Z_INDEX } from 'constants/css';
 import { CLIENT_PATH } from 'constants/path';
 
 export const Navbar = () => {
-  const themeContext = useThemeContext();
-  const getPathMatchResult = useMatchPath(themeContext.primary, themeContext.disabled);
-
-  const certColor = getPathMatchResult([CLIENT_PATH.CERT, CLIENT_PATH.CYCLE_DETAIL]);
-  const searchColor = getPathMatchResult([
-    CLIENT_PATH.SEARCH,
-    CLIENT_PATH.CHALLENGE_DETAIL,
-  ]);
-  const feedColor = getPathMatchResult([CLIENT_PATH.FEED]);
-  const profileColor = getPathMatchResult([
-    CLIENT_PATH.LOGIN,
-    CLIENT_PATH.SIGN_UP,
-    CLIENT_PATH.PROFILE,
-  ]);
+  const { certColor, searchColor, feedColor, profileColor } = useNavBar();
 
   return (
     <Footer>

--- a/frontend/src/components/Navbar/useNavBar.ts
+++ b/frontend/src/components/Navbar/useNavBar.ts
@@ -1,0 +1,28 @@
+import useMatchPath from 'hooks/useMatchPath';
+import useThemeContext from 'hooks/useThemeContext';
+
+import { CLIENT_PATH } from 'constants/path';
+
+export const useNavBar = () => {
+  const themeContext = useThemeContext();
+  const getPathMatchResult = useMatchPath(themeContext.primary, themeContext.disabled);
+
+  const certColor = getPathMatchResult([CLIENT_PATH.CERT, CLIENT_PATH.CYCLE_DETAIL]);
+  const searchColor = getPathMatchResult([
+    CLIENT_PATH.SEARCH,
+    CLIENT_PATH.CHALLENGE_DETAIL,
+  ]);
+  const feedColor = getPathMatchResult([CLIENT_PATH.FEED]);
+  const profileColor = getPathMatchResult([
+    CLIENT_PATH.LOGIN,
+    CLIENT_PATH.SIGN_UP,
+    CLIENT_PATH.PROFILE,
+  ]);
+
+  return {
+    certColor,
+    searchColor,
+    feedColor,
+    profileColor,
+  };
+};

--- a/frontend/src/components/PrivateOutlet/index.tsx
+++ b/frontend/src/components/PrivateOutlet/index.tsx
@@ -3,16 +3,11 @@ import { Navigate, Outlet } from 'react-router-dom';
 import useSnackBar from 'hooks/useSnackBar';
 
 import { LoadingSpinner } from 'components/LoadingSpinner';
+import { PrivateOutletProps } from 'components/PrivateOutlet/type';
 
 import { CLIENT_PATH } from 'constants/path';
 
-export const PrivateOutlet = ({
-  isLogin,
-  isLoading,
-}: {
-  isLogin: boolean;
-  isLoading: boolean;
-}) => {
+export const PrivateOutlet = ({ isLogin, isLoading }: PrivateOutletProps) => {
   const renderSnackBar = useSnackBar();
 
   if (isLoading) return <LoadingSpinner />;

--- a/frontend/src/components/PrivateOutlet/index.tsx
+++ b/frontend/src/components/PrivateOutlet/index.tsx
@@ -17,7 +17,9 @@ export const PrivateOutlet = ({ isLogin, isLoading }: PrivateOutletProps) => {
       message: '로그인이 필요한 페이지입니다.',
       status: 'ERROR',
     });
+
+    return <Navigate to={CLIENT_PATH.HOME} />;
   }
 
-  return isLogin ? <Outlet /> : <Navigate to={CLIENT_PATH.HOME} />;
+  return <Outlet />;
 };

--- a/frontend/src/components/PrivateOutlet/type.ts
+++ b/frontend/src/components/PrivateOutlet/type.ts
@@ -1,0 +1,4 @@
+export interface PrivateOutletProps {
+  isLogin: boolean;
+  isLoading: boolean;
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -30,3 +30,4 @@ export * from 'components/CycleDetailItem';
 export * from 'components/CycleDetailList';
 export * from 'components/Title';
 export * from 'components/LoadingButton';
+export * from 'components/InfiniteScroll';

--- a/frontend/src/pages/SearchPage/index.tsx
+++ b/frontend/src/pages/SearchPage/index.tsx
@@ -1,36 +1,18 @@
 import { useSearchPage } from 'pages/SearchPage/useSearchPage';
 
-import { FlexBox, ChallengeItem, LoadingSpinner, ChallengeList } from 'components';
-import { ChallengeInfo } from 'components/ChallengeList/type';
+import { FlexBox, LoadingSpinner, ChallengeList } from 'components';
 
 const SearchPage = () => {
-  const { rootRef, targetRef, isFetching, data, refetch } = useSearchPage();
-
-  if (typeof data === 'undefined') {
-    return <LoadingSpinner />;
-  }
+  const { rootRef, targetRef, isFetching, challengeListData, challengeListRefetch } =
+    useSearchPage();
 
   return (
-    <FlexBox as="ul" ref={rootRef} flexDirection="column" gap="27px">
-      {data.pages.map((page, pageIndex) => {
-        if (typeof page === 'undefined' || typeof page.data === 'undefined') {
-          return [];
-        }
-
-        return page.data.map((challengeInfo: ChallengeInfo, challengeIndex: number) => (
-          <li
-            key={challengeInfo.challengeId}
-            ref={
-              pageIndex === data.pages.length - 1 &&
-              challengeIndex === page.data.length - 1
-                ? targetRef
-                : undefined
-            }
-          >
-            <ChallengeItem {...challengeInfo} challengeListRefetch={refetch} />
-          </li>
-        ));
-      })}
+    <FlexBox ref={rootRef} flexDirection="column">
+      <ChallengeList
+        targetRef={targetRef}
+        challengeListData={challengeListData}
+        challengeListRefetch={challengeListRefetch}
+      />
       {isFetching && <LoadingSpinner />}
     </FlexBox>
   );

--- a/frontend/src/pages/SearchPage/index.tsx
+++ b/frontend/src/pages/SearchPage/index.tsx
@@ -3,16 +3,11 @@ import { useSearchPage } from 'pages/SearchPage/useSearchPage';
 import { FlexBox, LoadingSpinner, ChallengeList } from 'components';
 
 const SearchPage = () => {
-  const { rootRef, targetRef, isFetching, challengeListData, challengeListRefetch } =
-    useSearchPage();
+  const { rootRef, targetRef, isFetching, challengeListData } = useSearchPage();
 
   return (
     <FlexBox ref={rootRef} flexDirection="column">
-      <ChallengeList
-        targetRef={targetRef}
-        challengeListData={challengeListData}
-        challengeListRefetch={challengeListRefetch}
-      />
+      <ChallengeList targetRef={targetRef} challengeListData={challengeListData} />
       {isFetching && <LoadingSpinner />}
     </FlexBox>
   );

--- a/frontend/src/pages/SearchPage/index.tsx
+++ b/frontend/src/pages/SearchPage/index.tsx
@@ -1,14 +1,29 @@
 import { useSearchPage } from 'pages/SearchPage/useSearchPage';
 
-import { FlexBox, LoadingSpinner, ChallengeList } from 'components';
+import { LoadingSpinner, ChallengeItem, FlexBox, InfiniteScroll } from 'components';
 
 const SearchPage = () => {
-  const { rootRef, targetRef, isFetching, challengeListData } = useSearchPage();
+  const { isFetching, challengeInfiniteData, hasNextPage, fetchNextPage } =
+    useSearchPage();
 
   return (
-    <FlexBox ref={rootRef} flexDirection="column">
-      <ChallengeList targetRef={targetRef} challengeListData={challengeListData} />
-      {isFetching && <LoadingSpinner />}
+    <FlexBox flexDirection="column">
+      <InfiniteScroll
+        loadMore={fetchNextPage}
+        hasMore={hasNextPage}
+        isFetching={isFetching}
+        loader={<LoadingSpinner />}
+      >
+        <FlexBox as="ul" flexDirection="column" gap="27px">
+          {challengeInfiniteData?.pages.map((page) =>
+            page?.data.map((challengeInfo) => (
+              <li key={challengeInfo.challengeId}>
+                <ChallengeItem {...challengeInfo} />
+              </li>
+            )),
+          )}
+        </FlexBox>
+      </InfiniteScroll>
     </FlexBox>
   );
 };

--- a/frontend/src/pages/SearchPage/index.tsx
+++ b/frontend/src/pages/SearchPage/index.tsx
@@ -1,7 +1,39 @@
-import { ChallengeList } from 'components';
+import { useSearchPage } from 'pages/SearchPage/useSearchPage';
+
+import { FlexBox, ChallengeItem, LoadingSpinner, ChallengeList } from 'components';
+import { ChallengeInfo } from 'components/ChallengeList/type';
 
 const SearchPage = () => {
-  return <ChallengeList />;
+  const { rootRef, targetRef, isFetching, data, refetch } = useSearchPage();
+
+  if (typeof data === 'undefined') {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <FlexBox as="ul" ref={rootRef} flexDirection="column" gap="27px">
+      {data.pages.map((page, pageIndex) => {
+        if (typeof page === 'undefined' || typeof page.data === 'undefined') {
+          return [];
+        }
+
+        return page.data.map((challengeInfo: ChallengeInfo, challengeIndex: number) => (
+          <li
+            key={challengeInfo.challengeId}
+            ref={
+              pageIndex === data.pages.length - 1 &&
+              challengeIndex === page.data.length - 1
+                ? targetRef
+                : undefined
+            }
+          >
+            <ChallengeItem {...challengeInfo} challengeListRefetch={refetch} />
+          </li>
+        ));
+      })}
+      {isFetching && <LoadingSpinner />}
+    </FlexBox>
+  );
 };
 
 export default SearchPage;

--- a/frontend/src/pages/SearchPage/useSearchPage.ts
+++ b/frontend/src/pages/SearchPage/useSearchPage.ts
@@ -1,32 +1,19 @@
 import { useGetAllChallenges } from 'apis';
-import { useRef, RefObject, useMemo } from 'react';
-
-import useIntersect from 'hooks/useIntersect';
 
 export const useSearchPage = () => {
-  const { isFetching, data, hasNextPage, fetchNextPage } = useGetAllChallenges({
+  const {
+    isFetching,
+    data: challengeInfiniteData,
+    hasNextPage,
+    fetchNextPage,
+  } = useGetAllChallenges({
     refetchOnWindowFocus: false,
   });
 
-  const challengeListData = useMemo(() => {
-    return data?.pages.map((page) => page?.data).flat();
-  }, [data]);
-
-  const rootRef = useRef() as RefObject<HTMLDivElement>;
-
-  const options = useMemo(() => ({ root: rootRef.current, threshold: 0.5 }), []);
-
-  const targetRef = useIntersect<HTMLLIElement>((entry, observer) => {
-    if (hasNextPage) {
-      fetchNextPage();
-    }
-    observer.unobserve(entry.target);
-  }, options);
-
   return {
-    rootRef,
-    targetRef,
     isFetching,
-    challengeListData,
+    challengeInfiniteData,
+    hasNextPage,
+    fetchNextPage,
   };
 };

--- a/frontend/src/pages/SearchPage/useSearchPage.ts
+++ b/frontend/src/pages/SearchPage/useSearchPage.ts
@@ -1,0 +1,29 @@
+import { useGetAllChallenges } from 'apis';
+import { useRef, RefObject, useMemo } from 'react';
+
+import useIntersect from 'hooks/useIntersect';
+
+export const useSearchPage = () => {
+  const { isFetching, data, refetch, hasNextPage, fetchNextPage } = useGetAllChallenges({
+    refetchOnWindowFocus: false,
+  });
+
+  const rootRef = useRef() as RefObject<HTMLUListElement>;
+
+  const options = useMemo(() => ({ root: rootRef.current, threshold: 0.5 }), []);
+
+  const targetRef = useIntersect<HTMLLIElement>((entry, observer) => {
+    if (hasNextPage) {
+      fetchNextPage();
+    }
+    observer.unobserve(entry.target);
+  }, options);
+
+  return {
+    rootRef,
+    targetRef,
+    isFetching,
+    data,
+    refetch,
+  };
+};

--- a/frontend/src/pages/SearchPage/useSearchPage.ts
+++ b/frontend/src/pages/SearchPage/useSearchPage.ts
@@ -4,11 +4,33 @@ import { useRef, RefObject, useMemo } from 'react';
 import useIntersect from 'hooks/useIntersect';
 
 export const useSearchPage = () => {
-  const { isFetching, data, refetch, hasNextPage, fetchNextPage } = useGetAllChallenges({
+  const {
+    isFetching,
+    data,
+    refetch: challengeListRefetch,
+    hasNextPage,
+    fetchNextPage,
+  } = useGetAllChallenges({
     refetchOnWindowFocus: false,
   });
 
-  const rootRef = useRef() as RefObject<HTMLUListElement>;
+  const challengeListData = useMemo(() => {
+    if (typeof data === 'undefined') {
+      return null;
+    }
+
+    return data.pages
+      .map((page) => {
+        if (typeof page === 'undefined' || typeof page.data === 'undefined') {
+          return [];
+        }
+
+        return page.data;
+      })
+      .flat();
+  }, [data]);
+
+  const rootRef = useRef() as RefObject<HTMLDivElement>;
 
   const options = useMemo(() => ({ root: rootRef.current, threshold: 0.5 }), []);
 
@@ -24,6 +46,7 @@ export const useSearchPage = () => {
     targetRef,
     isFetching,
     data,
-    refetch,
+    challengeListData,
+    challengeListRefetch,
   };
 };

--- a/frontend/src/pages/SearchPage/useSearchPage.ts
+++ b/frontend/src/pages/SearchPage/useSearchPage.ts
@@ -15,19 +15,7 @@ export const useSearchPage = () => {
   });
 
   const challengeListData = useMemo(() => {
-    if (typeof data === 'undefined') {
-      return null;
-    }
-
-    return data.pages
-      .map((page) => {
-        if (typeof page === 'undefined' || typeof page.data === 'undefined') {
-          return [];
-        }
-
-        return page.data;
-      })
-      .flat();
+    return data?.pages.map((page) => page?.data).flat();
   }, [data]);
 
   const rootRef = useRef() as RefObject<HTMLDivElement>;

--- a/frontend/src/pages/SearchPage/useSearchPage.ts
+++ b/frontend/src/pages/SearchPage/useSearchPage.ts
@@ -4,13 +4,7 @@ import { useRef, RefObject, useMemo } from 'react';
 import useIntersect from 'hooks/useIntersect';
 
 export const useSearchPage = () => {
-  const {
-    isFetching,
-    data,
-    refetch: challengeListRefetch,
-    hasNextPage,
-    fetchNextPage,
-  } = useGetAllChallenges({
+  const { isFetching, data, hasNextPage, fetchNextPage } = useGetAllChallenges({
     refetchOnWindowFocus: false,
   });
 
@@ -33,8 +27,6 @@ export const useSearchPage = () => {
     rootRef,
     targetRef,
     isFetching,
-    data,
     challengeListData,
-    challengeListRefetch,
   };
 };


### PR DESCRIPTION
close #126 

# UI 로직을 컴포넌트에서 분리
## 컴포넌트
- [x] Header
- [x] Input
- [x] LandingNavigation
- [x] LinkText
- [x] LoadingButton
- [x] LoadingSpinner
- [x] Logo
- [x] NavBar
- [x] PrivateOutlet

## 페이지
- [x] ProfilePage
- [x] SearchPage

# 추가 작업
1. 기존 ChallengeList 컴포넌트에 있는 코드를 SearchPage로 이동. 추가적으로 ChallengeList 컴포넌트는 주입받은 배열 데이터를 map 하는 역할로 수정
2. LoadingButton, PrivateOutlet, LadingNavigation 컴포넌트에 삼항연사자 대신 Early Return 적용
