### PR TITLE
refactor: 컴포넌트에서 UI 로직을 페이지 커스텀훅으로 분리(3)

### DIFF
--- a/frontend/src/components/CardGridContainer/index.tsx
+++ b/frontend/src/components/CardGridContainer/index.tsx
@@ -5,15 +5,16 @@ import { getEmoji } from 'utils/emoji';
 
 import useThemeContext from 'hooks/useThemeContext';
 
-import { CardBox, Text, EmptyContent } from 'components';
+import { CardBox, Text, EmptyContent, LoadingSpinner, InfiniteScroll } from 'components';
 
 import { CLIENT_PATH } from 'constants/path';
 
 export const CardGridContainer = () => {
   const themeContext = useThemeContext();
-  const { data, loadMore } = useCardGridContainer();
+  const { successChallengeInfiniteData, hasNextPage, fetchNextPage, isFetching } =
+    useCardGridContainer();
 
-  if (data?.pages[0].data.length === 0) {
+  if (successChallengeInfiniteData?.pages[0].data.length === 0) {
     return (
       <EmptyContent
         title="아직 성공한 챌린지가 없습니다 :)"
@@ -30,18 +31,25 @@ export const CardGridContainer = () => {
         성공한 챌린지
       </Text>
       <Line />
-      <Grid>
-        {data?.pages.map((page) =>
-          page?.data?.map((challenge: Challenge) => (
-            <CardBox
-              key={challenge.challengeId}
-              {...challenge}
-              bgColor="#E6D1F2"
-              emoji={getEmoji(challenge.challengeId)}
-            />
-          )),
-        )}
-      </Grid>
+      <InfiniteScroll
+        loadMore={fetchNextPage}
+        hasMore={hasNextPage}
+        isFetching={isFetching}
+        loader={<LoadingSpinner />}
+      >
+        <Grid>
+          {successChallengeInfiniteData?.pages.map((page) =>
+            page?.data?.map((challenge: Challenge) => (
+              <CardBox
+                key={challenge.challengeId}
+                {...challenge}
+                bgColor="#E6D1F2"
+                emoji={getEmoji(challenge.challengeId)}
+              />
+            )),
+          )}
+        </Grid>
+      </InfiniteScroll>
     </div>
   );
 };

--- a/frontend/src/components/CardGridContainer/index.tsx
+++ b/frontend/src/components/CardGridContainer/index.tsx
@@ -1,4 +1,4 @@
-import { useGetMySuccessChallenges } from 'apis';
+import useCardGridContainer from './useCardGridContainer';
 import { Challenge } from 'commonType';
 import styled from 'styled-components';
 import { getEmoji } from 'utils/emoji';
@@ -10,15 +10,8 @@ import { CardBox, Text, EmptyContent } from 'components';
 import { CLIENT_PATH } from 'constants/path';
 
 export const CardGridContainer = () => {
-  // TODO : 성공한 챌린지 GET API 연결
   const themeContext = useThemeContext();
-  const { data, hasNextPage, fetchNextPage } = useGetMySuccessChallenges();
-
-  const loadMore = () => {
-    if (hasNextPage) {
-      fetchNextPage();
-    }
-  };
+  const { data, loadMore } = useCardGridContainer();
 
   if (data?.pages[0].data.length === 0) {
     return (
@@ -38,16 +31,16 @@ export const CardGridContainer = () => {
       </Text>
       <Line />
       <Grid>
-        {data?.pages.map((page) => {
-          return page?.data?.map((challenge: Challenge) => (
+        {data?.pages.map((page) =>
+          page?.data?.map((challenge: Challenge) => (
             <CardBox
               key={challenge.challengeId}
               {...challenge}
               bgColor="#E6D1F2"
               emoji={getEmoji(challenge.challengeId)}
             />
-          ));
-        })}
+          )),
+        )}
       </Grid>
     </div>
   );

--- a/frontend/src/components/CardGridContainer/useCardGridContainer.ts
+++ b/frontend/src/components/CardGridContainer/useCardGridContainer.ts
@@ -1,0 +1,15 @@
+import { useGetMySuccessChallenges } from 'apis';
+
+const useCardGridContainer = () => {
+  const { data, hasNextPage, fetchNextPage } = useGetMySuccessChallenges();
+
+  const loadMore = () => {
+    if (hasNextPage) {
+      fetchNextPage();
+    }
+  };
+
+  return { data, loadMore };
+};
+
+export default useCardGridContainer;

--- a/frontend/src/components/CardGridContainer/useCardGridContainer.ts
+++ b/frontend/src/components/CardGridContainer/useCardGridContainer.ts
@@ -1,15 +1,16 @@
 import { useGetMySuccessChallenges } from 'apis';
 
 const useCardGridContainer = () => {
-  const { data, hasNextPage, fetchNextPage } = useGetMySuccessChallenges();
+  const {
+    data: successChallengeInfiniteData,
+    hasNextPage,
+    fetchNextPage,
+    isFetching,
+  } = useGetMySuccessChallenges({
+    refetchOnWindowFocus: false,
+  });
 
-  const loadMore = () => {
-    if (hasNextPage) {
-      fetchNextPage();
-    }
-  };
-
-  return { data, loadMore };
+  return { successChallengeInfiniteData, hasNextPage, fetchNextPage, isFetching };
 };
 
 export default useCardGridContainer;

--- a/frontend/src/components/CertItem/index.tsx
+++ b/frontend/src/components/CertItem/index.tsx
@@ -1,6 +1,4 @@
 import useCertItem from './useCertItem';
-import { MouseEvent } from 'react';
-import { useNavigate } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import { getEmoji } from 'utils/emoji';
 
@@ -9,7 +7,6 @@ import useThemeContext from 'hooks/useThemeContext';
 import { FlexBox, Text, Button, CheckCircles, Timer, ThumbnailWrapper } from 'components';
 import { CertItemProps } from 'components/CertItem/type';
 
-import { CLIENT_PATH } from 'constants/path';
 import { cursorPointer } from 'constants/style';
 
 export const CertItem = ({
@@ -20,36 +17,22 @@ export const CertItem = ({
   startTime,
   successCount,
 }: CertItemProps) => {
-  const navigate = useNavigate();
   const themeContext = useThemeContext();
-  const { certEndDate, isCertPossible } = useCertItem({ startTime, progressCount });
-
-  const handleClickWrapper = (e: MouseEvent) => {
-    if (e.target instanceof HTMLButtonElement) {
-      return;
-    }
-
-    navigate(`${CLIENT_PATH.CYCLE_DETAIL}/${cycleId}`);
-  };
-
-  const handleClickButton = () => {
-    navigate(CLIENT_PATH.CERT, {
-      state: {
-        isInCertFormPage: true,
-        cycleId,
-        challengeId,
-        challengeName,
-        progressCount,
-        successCount,
-      },
+  const { certEndDate, isCertPossible, handleClickWrapper, handleClickButton } =
+    useCertItem({
+      cycleId,
+      challengeId,
+      challengeName,
+      progressCount,
+      startTime,
+      successCount,
     });
-  };
 
   return (
     <Wrapper
       flexDirection="column"
       gap="1rem"
-      onClick={(e) => handleClickWrapper(e)}
+      onClick={handleClickWrapper}
       style={{ ...cursorPointer }}
     >
       <TitleWrapper justifyContent="space-between">

--- a/frontend/src/components/CertItem/index.tsx
+++ b/frontend/src/components/CertItem/index.tsx
@@ -1,7 +1,7 @@
+import useCertItem from './useCertItem';
 import { MouseEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled, { css } from 'styled-components';
-import { addDays } from 'utils';
 import { getEmoji } from 'utils/emoji';
 
 import useThemeContext from 'hooks/useThemeContext';
@@ -9,7 +9,6 @@ import useThemeContext from 'hooks/useThemeContext';
 import { FlexBox, Text, Button, CheckCircles, Timer, ThumbnailWrapper } from 'components';
 import { CertItemProps } from 'components/CertItem/type';
 
-import { CYCLE_UNIT } from 'constants/domain';
 import { CLIENT_PATH } from 'constants/path';
 import { cursorPointer } from 'constants/style';
 
@@ -21,14 +20,9 @@ export const CertItem = ({
   startTime,
   successCount,
 }: CertItemProps) => {
-  const themeContext = useThemeContext();
   const navigate = useNavigate();
-
-  const nowDate = new Date();
-  const certStartDate = addDays(new Date(startTime), progressCount);
-  const certEndDate = addDays(new Date(startTime), progressCount + CYCLE_UNIT);
-
-  const isCertPossible = certStartDate <= nowDate && nowDate < certEndDate;
+  const themeContext = useThemeContext();
+  const { certEndDate, isCertPossible } = useCertItem({ startTime, progressCount });
 
   const handleClickWrapper = (e: MouseEvent) => {
     if (e.target instanceof HTMLButtonElement) {

--- a/frontend/src/components/CertItem/type.ts
+++ b/frontend/src/components/CertItem/type.ts
@@ -1,5 +1,3 @@
 import { Cycle } from 'commonType';
 
-export type CertItemProps = Cycle;
-
-export type useCertItemProps = Pick<CertItemProps, 'startTime' | 'progressCount'>;
+export type CertItemProps = Omit<Cycle, 'challengerCount'>;

--- a/frontend/src/components/CertItem/type.ts
+++ b/frontend/src/components/CertItem/type.ts
@@ -1,3 +1,5 @@
 import { Cycle } from 'commonType';
 
-export interface CertItemProps extends Cycle {}
+export type CertItemProps = Cycle;
+
+export type useCertItemProps = Pick<CertItemProps, 'startTime' | 'progressCount'>;

--- a/frontend/src/components/CertItem/useCertItem.ts
+++ b/frontend/src/components/CertItem/useCertItem.ts
@@ -1,0 +1,15 @@
+import { useCertItemProps } from './type';
+import { addDays } from 'utils';
+
+import { CYCLE_UNIT } from 'constants/domain';
+
+const useCertItem = ({ startTime, progressCount }: useCertItemProps) => {
+  const nowDate = new Date();
+  const certStartDate = addDays(new Date(startTime), progressCount);
+  const certEndDate = addDays(new Date(startTime), progressCount + CYCLE_UNIT);
+
+  const isCertPossible = certStartDate <= nowDate && nowDate < certEndDate;
+  return { certEndDate, isCertPossible };
+};
+
+export default useCertItem;

--- a/frontend/src/components/CertItem/useCertItem.ts
+++ b/frontend/src/components/CertItem/useCertItem.ts
@@ -1,15 +1,48 @@
-import { useCertItemProps } from './type';
+import { CertItemProps } from './type';
+import { MouseEventHandler } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { addDays } from 'utils';
 
 import { CYCLE_UNIT } from 'constants/domain';
+import { CLIENT_PATH } from 'constants/path';
 
-const useCertItem = ({ startTime, progressCount }: useCertItemProps) => {
+const useCertItem = ({
+  cycleId,
+  challengeId,
+  challengeName,
+  progressCount,
+  startTime,
+  successCount,
+}: CertItemProps) => {
+  const navigate = useNavigate();
   const nowDate = new Date();
   const certStartDate = addDays(new Date(startTime), progressCount);
   const certEndDate = addDays(new Date(startTime), progressCount + CYCLE_UNIT);
 
   const isCertPossible = certStartDate <= nowDate && nowDate < certEndDate;
-  return { certEndDate, isCertPossible };
+
+  const handleClickWrapper: MouseEventHandler<HTMLDivElement> = (e) => {
+    if (e.target instanceof HTMLButtonElement) {
+      return;
+    }
+
+    navigate(`${CLIENT_PATH.CYCLE_DETAIL}/${cycleId}`);
+  };
+
+  const handleClickButton = () => {
+    navigate(CLIENT_PATH.CERT, {
+      state: {
+        isInCertFormPage: true,
+        cycleId,
+        challengeId,
+        challengeName,
+        progressCount,
+        successCount,
+      },
+    });
+  };
+
+  return { certEndDate, isCertPossible, handleClickWrapper, handleClickButton };
 };
 
 export default useCertItem;

--- a/frontend/src/components/ChallengeItem/index.tsx
+++ b/frontend/src/components/ChallengeItem/index.tsx
@@ -4,7 +4,6 @@ import { Link, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { getEmoji } from 'utils/emoji';
 
-import usePostJoinChallenge from 'hooks/usePostJoinChallenge';
 import useThemeContext from 'hooks/useThemeContext';
 
 import { Text, FlexBox, Button, ThumbnailWrapper } from 'components';
@@ -18,6 +17,7 @@ export const ChallengeItem = ({
   challengerCount,
   isInProgress,
 }: ChallengeItemProps) => {
+  const navigate = useNavigate();
   const themeContext = useThemeContext();
   const queryClient = useQueryClient();
 

--- a/frontend/src/components/ChallengeItem/index.tsx
+++ b/frontend/src/components/ChallengeItem/index.tsx
@@ -1,3 +1,5 @@
+import { queryKeys } from 'apis/constants';
+import { useQueryClient } from 'react-query';
 import { Link, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { getEmoji } from 'utils/emoji';
@@ -15,13 +17,15 @@ export const ChallengeItem = ({
   challengeName,
   challengerCount,
   isInProgress,
-  challengeListRefetch,
 }: ChallengeItemProps) => {
   const themeContext = useThemeContext();
+  const queryClient = useQueryClient();
 
   const { joinChallenge } = usePostJoinChallenge({
     challengeId: Number(challengeId),
-    successCallback: challengeListRefetch,
+    successCallback: () => {
+      queryClient.invalidateQueries(queryKeys.getAllChallenges);
+    },
   });
 
   const navigate = useNavigate();

--- a/frontend/src/components/ChallengeItem/index.tsx
+++ b/frontend/src/components/ChallengeItem/index.tsx
@@ -1,6 +1,5 @@
-import { queryKeys } from 'apis/constants';
-import { useQueryClient } from 'react-query';
-import { Link, useNavigate } from 'react-router-dom';
+import useChallengeItem from './useChallengeItem';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { getEmoji } from 'utils/emoji';
 
@@ -17,24 +16,12 @@ export const ChallengeItem = ({
   challengerCount,
   isInProgress,
 }: ChallengeItemProps) => {
-  const navigate = useNavigate();
-  const navigate = useNavigate();
   const themeContext = useThemeContext();
-  const queryClient = useQueryClient();
-
-  const { joinChallenge } = usePostJoinChallenge({
-    challengeId: Number(challengeId),
-    successCallback: () => {
-      queryClient.invalidateQueries(queryKeys.getAllChallenges);
-    },
+  const handleClickProgressButton = useChallengeItem({
+    challengeId,
+    challengeName,
+    isInProgress,
   });
-
-  const navigate = useNavigate();
-  const handleClickProgressButton = () => {
-    isInProgress
-      ? navigate(`${CLIENT_PATH.CHALLENGE_DETAIL}/${challengeId}`)
-      : joinChallenge(challengeName);
-  };
 
   return (
     <Wrapper justifyContent="space-between" alignItems="center">
@@ -66,7 +53,6 @@ const Wrapper = styled(FlexBox)`
   div {
     flex-grow: 1;
   }
-
   ${Button} {
     flex-grow: 0;
   }

--- a/frontend/src/components/ChallengeItem/type.ts
+++ b/frontend/src/components/ChallengeItem/type.ts
@@ -4,3 +4,8 @@ export interface ChallengeItemProps {
   challengerCount: number;
   isInProgress: boolean;
 }
+
+export type useChallengeItemProps = Pick<
+  ChallengeItemProps,
+  'challengeId' | 'challengeListRefetch'
+>;

--- a/frontend/src/components/ChallengeItem/type.ts
+++ b/frontend/src/components/ChallengeItem/type.ts
@@ -7,5 +7,5 @@ export interface ChallengeItemProps {
 
 export type useChallengeItemProps = Pick<
   ChallengeItemProps,
-  'challengeId' | 'challengeListRefetch'
+  'challengeId' | 'challengeName' | 'isInProgress'
 >;

--- a/frontend/src/components/ChallengeItem/type.ts
+++ b/frontend/src/components/ChallengeItem/type.ts
@@ -3,5 +3,4 @@ export interface ChallengeItemProps {
   challengeName: string;
   challengerCount: number;
   isInProgress: boolean;
-  challengeListRefetch: () => void;
 }

--- a/frontend/src/components/ChallengeItem/useChallengeItem.ts
+++ b/frontend/src/components/ChallengeItem/useChallengeItem.ts
@@ -1,17 +1,34 @@
 import { useChallengeItemProps } from './type';
+import { queryKeys } from 'apis/constants';
+import { useQueryClient } from 'react-query';
+import { useNavigate } from 'react-router-dom';
 
 import usePostJoinChallenge from 'hooks/usePostJoinChallenge';
 
+import { CLIENT_PATH } from 'constants/path';
+
 const useChallengeItem = ({
   challengeId,
-  challengeListRefetch,
+  isInProgress,
+  challengeName,
 }: useChallengeItemProps) => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
   const { joinChallenge } = usePostJoinChallenge({
     challengeId: Number(challengeId),
-    successCallback: challengeListRefetch,
+    successCallback: () => {
+      queryClient.invalidateQueries(queryKeys.getAllChallenges);
+    },
   });
 
-  return joinChallenge;
+  const handleClickProgressButton = () => {
+    isInProgress
+      ? navigate(`${CLIENT_PATH.CHALLENGE_DETAIL}/${challengeId}`)
+      : joinChallenge(challengeName);
+  };
+
+  return handleClickProgressButton;
 };
 
 export default useChallengeItem;

--- a/frontend/src/components/ChallengeItem/useChallengeItem.ts
+++ b/frontend/src/components/ChallengeItem/useChallengeItem.ts
@@ -1,0 +1,17 @@
+import { useChallengeItemProps } from './type';
+
+import usePostJoinChallenge from 'hooks/usePostJoinChallenge';
+
+const useChallengeItem = ({
+  challengeId,
+  challengeListRefetch,
+}: useChallengeItemProps) => {
+  const { joinChallenge } = usePostJoinChallenge({
+    challengeId: Number(challengeId),
+    successCallback: challengeListRefetch,
+  });
+
+  return joinChallenge;
+};
+
+export default useChallengeItem;

--- a/frontend/src/components/ChallengeList/ChallengeList.stories.tsx
+++ b/frontend/src/components/ChallengeList/ChallengeList.stories.tsx
@@ -1,8 +1,17 @@
+import { challengeData } from 'mocks/data';
+
 import { ChallengeList } from 'components';
+import { ChallengeListProps } from 'components/ChallengeList/type';
 
 export default {
   title: 'Components/ChallengeList',
   component: ChallengeList,
 };
 
-export const DefaultChallengeList = () => <ChallengeList />;
+export const DefaultChallengeList = (args: ChallengeListProps) => (
+  <ChallengeList {...args} />
+);
+
+DefaultChallengeList.args = {
+  challengeListData: challengeData,
+};

--- a/frontend/src/components/ChallengeList/index.tsx
+++ b/frontend/src/components/ChallengeList/index.tsx
@@ -1,52 +1,17 @@
-import { useGetAllChallenges } from 'apis';
-import { useRef, RefObject, useMemo } from 'react';
+import { FlexBox, ChallengeItem } from 'components';
+import { ChallengeListProps } from 'components/ChallengeList/type';
 
-import useIntersect from 'hooks/useIntersect';
-
-import { FlexBox, ChallengeItem, LoadingSpinner } from 'components';
-import { ChallengeInfo } from 'components/ChallengeList/type';
-
-export const ChallengeList = () => {
-  const { isFetching, data, refetch, hasNextPage, fetchNextPage } = useGetAllChallenges({
-    refetchOnWindowFocus: false,
-  });
-
-  const rootRef = useRef() as RefObject<HTMLUListElement>;
-
-  const options = useMemo(() => ({ root: rootRef.current, threshold: 0.5 }), []);
-  const targetRef = useIntersect<HTMLLIElement>((entry, observer) => {
-    if (hasNextPage) {
-      fetchNextPage();
-    }
-    observer.unobserve(entry.target);
-  }, options);
-
-  if (typeof data === 'undefined') {
-    return <LoadingSpinner />;
-  }
-
+export const ChallengeList = ({ targetRef, challengeListData }: ChallengeListProps) => {
   return (
-    <FlexBox as="ul" ref={rootRef} flexDirection="column" gap="27px">
-      {data.pages.map((page, pageIndex) => {
-        if (typeof page === 'undefined' || typeof page.data === 'undefined') {
-          return [];
-        }
-
-        return page.data.map((challengeInfo: ChallengeInfo, challengeIndex: number) => (
-          <li
-            key={challengeInfo.challengeId}
-            ref={
-              pageIndex === data.pages.length - 1 &&
-              challengeIndex === page.data.length - 1
-                ? targetRef
-                : undefined
-            }
-          >
-            <ChallengeItem {...challengeInfo} challengeListRefetch={refetch} />
-          </li>
-        ));
-      })}
-      {isFetching && <LoadingSpinner />}
+    <FlexBox as="ul" flexDirection="column" gap="27px">
+      {challengeListData?.map((challengeInfo, challengeIndex) => (
+        <li
+          key={challengeInfo.challengeId}
+          ref={challengeIndex === challengeListData.length - 1 ? targetRef : undefined}
+        >
+          <ChallengeItem {...challengeInfo} />
+        </li>
+      ))}
     </FlexBox>
   );
 };

--- a/frontend/src/components/ChallengeList/type.ts
+++ b/frontend/src/components/ChallengeList/type.ts
@@ -1,3 +1,8 @@
+import { RefObject } from 'react';
+
 import { ChallengeItemProps } from 'components/ChallengeItem/type';
 
-export type ChallengeInfo = Omit<ChallengeItemProps, 'challengeListRefetch'>;
+export interface ChallengeListProps {
+  targetRef?: RefObject<HTMLLIElement>;
+  challengeListData?: ChallengeItemProps[];
+}

--- a/frontend/src/components/CheckCircles/index.tsx
+++ b/frontend/src/components/CheckCircles/index.tsx
@@ -1,31 +1,34 @@
 import { BsCheckCircleFill, BsFillCircleFill } from 'react-icons/bs';
-import styled from 'styled-components';
 
 import useThemeContext from 'hooks/useThemeContext';
 
 import { FlexBox } from 'components';
-import { CheckCirclesProps } from 'components/CheckCircles/type';
+import { CheckCircleProps, CheckCirclesProps } from 'components/CheckCircles/type';
 
 const totalCheck = [...Array(3)];
 
 export const CheckCircles = ({ progressCount }: CheckCirclesProps) => {
-  const themeContext = useThemeContext();
-
   return (
     <FlexBox gap="1rem">
-      {totalCheck.map((_, index) => {
-        if (index < progressCount) {
-          return <BsCheckCircleFill key={index} color={themeContext.primary} size={27} />;
-        }
-        return (
-          <BsFillCircleFill
-            style={{ border: `1px solid ${themeContext.surface}`, borderRadius: '50%' }}
-            key={index}
-            color={themeContext.secondary}
-            size={27}
-          />
-        );
-      })}
+      {totalCheck.map((_, index) => (
+        <CheckCircle key={index} checkCircleCount={index} progressCount={progressCount} />
+      ))}
     </FlexBox>
+  );
+};
+
+const CheckCircle = ({ checkCircleCount, progressCount }: CheckCircleProps) => {
+  const themeContext = useThemeContext();
+
+  if (checkCircleCount < progressCount) {
+    return <BsCheckCircleFill color={themeContext.primary} size={27} />;
+  }
+
+  return (
+    <BsFillCircleFill
+      style={{ border: `1px solid ${themeContext.surface}`, borderRadius: '50%' }}
+      color={themeContext.secondary}
+      size={27}
+    />
   );
 };

--- a/frontend/src/components/CheckCircles/type.ts
+++ b/frontend/src/components/CheckCircles/type.ts
@@ -1,3 +1,7 @@
 import { Cycle } from 'commonType';
 
 export type CheckCirclesProps = Pick<Cycle, 'progressCount'>;
+
+export interface CheckCircleProps extends CheckCirclesProps {
+  checkCircleCount: number;
+}

--- a/frontend/src/components/CycleDetailList/index.tsx
+++ b/frontend/src/components/CycleDetailList/index.tsx
@@ -21,9 +21,9 @@ export const CycleDetailList = ({ cycleDetails }: CycleDetailListProps) => {
 
   return (
     <FlexBox alignItems="center" flexDirection="column" gap="2rem">
-      {cycleDetails.map((cycleDetail) => {
-        return <CycleDetailItem key={cycleDetail.progressTime} {...cycleDetail} />;
-      })}
+      {cycleDetails.map((cycleDetail) => (
+        <CycleDetailItem key={cycleDetail.progressTime} {...cycleDetail} />
+      ))}
     </FlexBox>
   );
 };

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -1,32 +1,19 @@
-import { useGetLinkGoogle } from 'apis';
 import { FaBell } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
-import { useRecoilState } from 'recoil';
-import { isLoginState } from 'recoil/auth/atoms';
-import { isDarkState } from 'recoil/darkMode/atoms';
 import styled, { css } from 'styled-components';
 
 import useThemeContext from 'hooks/useThemeContext';
 
 import { Logo, FlexBox, Button, ToggleButton } from 'components';
 import { HeaderProps } from 'components/Header/type';
+import { useHeader } from 'components/Header/useHeader';
 
 import { Z_INDEX } from 'constants/css';
 import { CLIENT_PATH } from 'constants/path';
 
 export const Header = ({ bgColor }: HeaderProps) => {
-  const [isDark, setIsDark] = useRecoilState(isDarkState);
-
-  const isLogin = useRecoilValue(isLoginState);
   const themeContext = useThemeContext();
-
-  const { refetch: redirectGoogleLoginLink } = useGetLinkGoogle();
-
-  const handleDarkToggle = () => {
-    localStorage.setItem('isDark', JSON.stringify(!isDark));
-    setIsDark((prev) => !prev);
-  };
+  const { isDark, isLogin, handleDarkToggle, handleLoginButton } = useHeader();
 
   return (
     <Wrapper bgColor={bgColor} justifyContent="space-between" alignItems="center">
@@ -38,7 +25,7 @@ export const Header = ({ bgColor }: HeaderProps) => {
         {isLogin ? (
           <FaBell size={23} color={themeContext.primary} />
         ) : (
-          <Button size="small" onClick={() => redirectGoogleLoginLink()}>
+          <Button size="small" onClick={handleLoginButton}>
             로그인
           </Button>
         )}

--- a/frontend/src/components/Header/useHeader.ts
+++ b/frontend/src/components/Header/useHeader.ts
@@ -1,0 +1,28 @@
+import { useGetLinkGoogle } from 'apis';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { isLoginState } from 'recoil/auth/atoms';
+import { isDarkState } from 'recoil/darkMode/atoms';
+
+export const useHeader = () => {
+  const [isDark, setIsDark] = useRecoilState(isDarkState);
+
+  const isLogin = useRecoilValue(isLoginState);
+
+  const { refetch: redirectGoogleLoginLink } = useGetLinkGoogle();
+
+  const handleDarkToggle = () => {
+    localStorage.setItem('isDark', JSON.stringify(!isDark));
+    setIsDark((prev) => !prev);
+  };
+
+  const handleLoginButton = () => {
+    redirectGoogleLoginLink();
+  };
+
+  return {
+    isDark,
+    isLogin,
+    handleDarkToggle,
+    handleLoginButton,
+  };
+};

--- a/frontend/src/components/InfiniteScroll/index.tsx
+++ b/frontend/src/components/InfiniteScroll/index.tsx
@@ -1,0 +1,34 @@
+import { InfiniteScrollProps } from './type';
+import { RefObject, useMemo, useRef } from 'react';
+
+import useIntersect from 'hooks/useIntersect';
+
+import { FlexBox } from 'components';
+
+export const InfiniteScroll = ({
+  children,
+  loadMore,
+  hasMore,
+  isFetching,
+  loader,
+  threshold = 0.5,
+}: InfiniteScrollProps) => {
+  const rootRef = useRef() as RefObject<HTMLDivElement>;
+
+  const options = useMemo(() => ({ root: rootRef.current, threshold }), []);
+
+  const targetRef = useIntersect<HTMLDivElement>((entry, observer) => {
+    if (hasMore) {
+      loadMore();
+    }
+    observer.unobserve(entry.target);
+  }, options);
+
+  return (
+    <FlexBox ref={rootRef} flexDirection="column">
+      {children}
+      <div ref={targetRef} />
+      {isFetching && loader}
+    </FlexBox>
+  );
+};

--- a/frontend/src/components/InfiniteScroll/type.ts
+++ b/frontend/src/components/InfiniteScroll/type.ts
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react';
+
+export interface InfiniteScrollProps {
+  children: ReactNode;
+  loadMore: () => void;
+  hasMore?: boolean;
+  isFetching: boolean;
+  loader?: ReactNode;
+  threshold?: number;
+}

--- a/frontend/src/components/Input/index.tsx
+++ b/frontend/src/components/Input/index.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
 import styled, { css } from 'styled-components';
 
 import { InputProps, InputContainerProps } from 'components/Input/type';
+import { useInput } from 'components/Input/useInput';
 import { ValidationMessage } from 'components/ValidationMessage';
 
 export const Input = ({
@@ -14,7 +14,7 @@ export const Input = ({
   message,
   disabled,
 }: InputProps) => {
-  const [isFocus, setIsFocus] = useState(false);
+  const { isFocus, handleFocus, handleBlur } = useInput();
 
   return (
     <Wrapper>
@@ -26,8 +26,8 @@ export const Input = ({
           placeholder={placeholder}
           value={value}
           onChange={onChange}
-          onFocus={() => setIsFocus(true)}
-          onBlur={() => setIsFocus(false)}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
           disabled={disabled}
         />
       </InputWrapper>

--- a/frontend/src/components/Input/useInput.ts
+++ b/frontend/src/components/Input/useInput.ts
@@ -1,0 +1,19 @@
+import { useState } from 'react';
+
+export const useInput = () => {
+  const [isFocus, setIsFocus] = useState(false);
+
+  const handleFocus = () => {
+    setIsFocus(true);
+  };
+
+  const handleBlur = () => {
+    setIsFocus(false);
+  };
+
+  return {
+    isFocus,
+    handleFocus,
+    handleBlur,
+  };
+};

--- a/frontend/src/components/LandingNavigation/index.tsx
+++ b/frontend/src/components/LandingNavigation/index.tsx
@@ -1,21 +1,14 @@
 import { Navigate } from 'react-router-dom';
 
+import { LandingNavigationProps } from 'components/LandingNavigation/type';
 import { LoadingSpinner } from 'components/LoadingSpinner';
 
 import { CLIENT_PATH } from 'constants/path';
 
-export const LandingNavigation = ({
-  isLogin,
-  isLoading,
-}: {
-  isLogin: boolean;
-  isLoading: boolean;
-}) => {
+export const LandingNavigation = ({ isLogin, isLoading }: LandingNavigationProps) => {
   if (isLoading) return <LoadingSpinner />;
 
-  return isLogin ? (
-    <Navigate to={CLIENT_PATH.CERT} />
-  ) : (
-    <Navigate to={CLIENT_PATH.HOME} />
-  );
+  if (isLogin) return <Navigate to={CLIENT_PATH.CERT} />;
+
+  return <Navigate to={CLIENT_PATH.HOME} />;
 };

--- a/frontend/src/components/LandingNavigation/type.ts
+++ b/frontend/src/components/LandingNavigation/type.ts
@@ -1,0 +1,4 @@
+export interface LandingNavigationProps {
+  isLogin: boolean;
+  isLoading: boolean;
+}

--- a/frontend/src/components/LoadingButton/index.tsx
+++ b/frontend/src/components/LoadingButton/index.tsx
@@ -13,9 +13,9 @@ export const LoadingButton = ({
   loadingText,
   successText,
 }: LoadingButtonProps) => {
-  return (
-    <Element size="large" disabled={isDisabled || isLoading || isSuccess}>
-      {isLoading ? (
+  if (isLoading) {
+    return (
+      <Element size="large" disabled={true}>
         <FlexBox
           flexDirection="row"
           gap="1rem"
@@ -25,11 +25,21 @@ export const LoadingButton = ({
           {loadingText}
           <LoadingDots />
         </FlexBox>
-      ) : isSuccess ? (
-        successText
-      ) : (
-        defaultText
-      )}
+      </Element>
+    );
+  }
+
+  if (isSuccess) {
+    return (
+      <Element size="large" disabled={true}>
+        {successText}
+      </Element>
+    );
+  }
+
+  return (
+    <Element size="large" disabled={isDisabled}>
+      {defaultText}
     </Element>
   );
 };

--- a/frontend/src/components/LoadingSpinner/index.tsx
+++ b/frontend/src/components/LoadingSpinner/index.tsx
@@ -1,12 +1,14 @@
 import styled, { keyframes } from 'styled-components';
 
-const LoadingBox = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  gap: 50px;
-`;
+import { FlexBox } from 'components/';
+
+export const LoadingSpinner = () => {
+  return (
+    <FlexBox flexDirection="column" justifyContent="center" alignItems="center">
+      <Spinner />
+    </FlexBox>
+  );
+};
 
 const spin = keyframes`
   to { -webkit-transform: rotate(360deg); }
@@ -21,11 +23,3 @@ const Spinner = styled.div`
   animation: ${spin} 1s ease-in-out infinite;
   -webkit-animation: ${spin} 1s ease-in-out infinite;
 `;
-
-export const LoadingSpinner = () => {
-  return (
-    <LoadingBox>
-      <Spinner />
-    </LoadingBox>
-  );
-};

--- a/frontend/src/components/Logo/index.tsx
+++ b/frontend/src/components/Logo/index.tsx
@@ -3,14 +3,15 @@ import styled from 'styled-components';
 
 import { LogoProps } from 'components/Logo/type';
 
+const svg = {
+  start: { pathLength: 0, fill: 'rgba(255, 255, 255, 0)' },
+  end: {
+    fill: '#7B61FF',
+    pathLength: 1,
+  },
+};
+
 export const Logo = ({ width, color, isAnimated }: LogoProps) => {
-  const svg = {
-    start: { pathLength: 0, fill: 'rgba(255, 255, 255, 0)' },
-    end: {
-      fill: '#7B61FF',
-      pathLength: 1,
-    },
-  };
   return (
     <Svg width={width} viewBox="0 0 156 44" xmlns="http://www.w3.org/2000/svg">
       {isAnimated ? (

--- a/frontend/src/components/Navbar/index.tsx
+++ b/frontend/src/components/Navbar/index.tsx
@@ -5,30 +5,15 @@ import Search from 'assets/search.svg';
 import { Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
-import useMatchPath from 'hooks/useMatchPath';
-import useThemeContext from 'hooks/useThemeContext';
-
 import { Text, FlexBox } from 'components';
 import { NavLinkProps } from 'components/Navbar/type';
+import { useNavBar } from 'components/Navbar/useNavBar';
 
 import { Z_INDEX } from 'constants/css';
 import { CLIENT_PATH } from 'constants/path';
 
 export const Navbar = () => {
-  const themeContext = useThemeContext();
-  const getPathMatchResult = useMatchPath(themeContext.primary, themeContext.disabled);
-
-  const certColor = getPathMatchResult([CLIENT_PATH.CERT, CLIENT_PATH.CYCLE_DETAIL]);
-  const searchColor = getPathMatchResult([
-    CLIENT_PATH.SEARCH,
-    CLIENT_PATH.CHALLENGE_DETAIL,
-  ]);
-  const feedColor = getPathMatchResult([CLIENT_PATH.FEED]);
-  const profileColor = getPathMatchResult([
-    CLIENT_PATH.LOGIN,
-    CLIENT_PATH.SIGN_UP,
-    CLIENT_PATH.PROFILE,
-  ]);
+  const { certColor, searchColor, feedColor, profileColor } = useNavBar();
 
   return (
     <Footer>

--- a/frontend/src/components/Navbar/useNavBar.ts
+++ b/frontend/src/components/Navbar/useNavBar.ts
@@ -1,0 +1,28 @@
+import useMatchPath from 'hooks/useMatchPath';
+import useThemeContext from 'hooks/useThemeContext';
+
+import { CLIENT_PATH } from 'constants/path';
+
+export const useNavBar = () => {
+  const themeContext = useThemeContext();
+  const getPathMatchResult = useMatchPath(themeContext.primary, themeContext.disabled);
+
+  const certColor = getPathMatchResult([CLIENT_PATH.CERT, CLIENT_PATH.CYCLE_DETAIL]);
+  const searchColor = getPathMatchResult([
+    CLIENT_PATH.SEARCH,
+    CLIENT_PATH.CHALLENGE_DETAIL,
+  ]);
+  const feedColor = getPathMatchResult([CLIENT_PATH.FEED]);
+  const profileColor = getPathMatchResult([
+    CLIENT_PATH.LOGIN,
+    CLIENT_PATH.SIGN_UP,
+    CLIENT_PATH.PROFILE,
+  ]);
+
+  return {
+    certColor,
+    searchColor,
+    feedColor,
+    profileColor,
+  };
+};

--- a/frontend/src/components/PrivateOutlet/index.tsx
+++ b/frontend/src/components/PrivateOutlet/index.tsx
@@ -3,16 +3,11 @@ import { Navigate, Outlet } from 'react-router-dom';
 import useSnackBar from 'hooks/useSnackBar';
 
 import { LoadingSpinner } from 'components/LoadingSpinner';
+import { PrivateOutletProps } from 'components/PrivateOutlet/type';
 
 import { CLIENT_PATH } from 'constants/path';
 
-export const PrivateOutlet = ({
-  isLogin,
-  isLoading,
-}: {
-  isLogin: boolean;
-  isLoading: boolean;
-}) => {
+export const PrivateOutlet = ({ isLogin, isLoading }: PrivateOutletProps) => {
   const renderSnackBar = useSnackBar();
 
   if (isLoading) return <LoadingSpinner />;
@@ -22,7 +17,9 @@ export const PrivateOutlet = ({
       message: '로그인이 필요한 페이지입니다.',
       status: 'ERROR',
     });
+
+    return <Navigate to={CLIENT_PATH.HOME} />;
   }
 
-  return isLogin ? <Outlet /> : <Navigate to={CLIENT_PATH.HOME} />;
+  return <Outlet />;
 };

--- a/frontend/src/components/PrivateOutlet/type.ts
+++ b/frontend/src/components/PrivateOutlet/type.ts
@@ -1,0 +1,4 @@
+export interface PrivateOutletProps {
+  isLogin: boolean;
+  isLoading: boolean;
+}

--- a/frontend/src/components/Profile/index.tsx
+++ b/frontend/src/components/Profile/index.tsx
@@ -1,52 +1,29 @@
-import { useGetMyCyclesStat, useGetMyInfo } from 'apis';
-import { authApiClient } from 'apis/apiClient';
-import { MouseEventHandler } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useSetRecoilState } from 'recoil';
-import { isLoginState } from 'recoil/auth/atoms';
+import useProfile from './useProfile';
 import styled from 'styled-components';
 
 import useThemeContext from 'hooks/useThemeContext';
 
-import { FlexBox, Text, Button, LoadingSpinner } from 'components';
-
-import { CLIENT_PATH } from 'constants/path';
+import { FlexBox, Text, Button } from 'components';
 
 export const Profile = () => {
   const themeContext = useThemeContext();
+  const { myInfo, myCyclesStat, handleClickEdit, handleClickLogout } = useProfile();
 
-  const setIsLogin = useSetRecoilState(isLoginState);
-  const navigate = useNavigate();
-  const { data: dataMyInfo } = useGetMyInfo();
-  const { data: dataMyCyclesStat } = useGetMyCyclesStat();
-
-  if (typeof dataMyInfo === 'undefined' || typeof dataMyCyclesStat === 'undefined') {
-    return <LoadingSpinner />;
+  if (typeof myInfo === 'undefined' || typeof myCyclesStat === 'undefined') {
+    return null;
   }
 
-  const {
-    data: { nickname, introduction, picture },
-  } = dataMyInfo;
-  const profileImgAlt = { nickname } + ' 프로필 사진';
-
-  const {
-    data: { totalCount, successCount },
-  } = dataMyCyclesStat;
-
-  const handleClickEdit: MouseEventHandler<HTMLButtonElement> = () => {
-    navigate(CLIENT_PATH.PROFILE_EDIT);
-  };
-
-  const handleClickLogout: MouseEventHandler<HTMLButtonElement> = () => {
-    authApiClient.deleteAuth();
-    setIsLogin(false);
-    navigate(CLIENT_PATH.HOME);
-  };
+  const { picture, nickname, introduction } = myInfo.data;
+  const { totalCount, successCount } = myCyclesStat.data;
 
   return (
     <Wrapper flexDirection="column" justifyContent="center" gap="2.12rem">
       <FlexBox justifyContent="center" gap="2rem">
-        <ProfileImg aria-label="프로필 이미지" src={picture} alt={profileImgAlt} />
+        <ProfileImg
+          aria-label="프로필 이미지"
+          src={picture}
+          alt={`${nickname} 프로필 사진`}
+        />
         <FlexBox flexDirection="column" gap="0.4rem">
           <Text
             aria-label="닉네임"
@@ -56,7 +33,6 @@ export const Profile = () => {
           >
             {nickname}
           </Text>
-          {/* TODO: 프로필 편집 텍스트 width 제한. 이를 통해 자기 소개가 길어졌을 때 하단 프로필 편집, 로그아웃 버튼의 UI가 변경되는 문제 해결할 수 있음! */}
           <Text aria-label="자기소개" size={16} color={themeContext.onBackground}>
             {introduction}
           </Text>

--- a/frontend/src/components/Profile/index.tsx
+++ b/frontend/src/components/Profile/index.tsx
@@ -77,6 +77,21 @@ export const Profile = () => {
 const Wrapper = styled(FlexBox)`
   width: 100%;
   margin: 1rem 2.375rem 0;
+
+  /* PC (해상도 1024px)*/
+  /* 테블릿 가로, 테블릿 세로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) {
+    align-self: flex-start;
+    position: sticky;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  /* 모바일 가로, 모바일 세로 (해상도 480px ~ 767px)*/
+  @media all and (max-width: 767px) {
+    position: relative;
+  }
 `;
 
 const ProfileImg = styled.img`

--- a/frontend/src/components/Profile/useProfile.ts
+++ b/frontend/src/components/Profile/useProfile.ts
@@ -1,0 +1,36 @@
+import { useGetMyCyclesStat, useGetMyInfo } from 'apis';
+import { authApiClient } from 'apis/apiClient';
+import { MouseEventHandler } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
+import { isLoginState } from 'recoil/auth/atoms';
+
+import { LoadingSpinner } from 'components/LoadingSpinner';
+
+import { CLIENT_PATH } from 'constants/path';
+
+const useProfile = () => {
+  const setIsLogin = useSetRecoilState(isLoginState);
+  const navigate = useNavigate();
+  const { data: myInfo } = useGetMyInfo();
+  const { data: myCyclesStat } = useGetMyCyclesStat();
+
+  const handleClickEdit: MouseEventHandler<HTMLButtonElement> = () => {
+    navigate(CLIENT_PATH.PROFILE_EDIT);
+  };
+
+  const handleClickLogout: MouseEventHandler<HTMLButtonElement> = () => {
+    authApiClient.deleteAuth();
+    setIsLogin(false);
+    navigate(CLIENT_PATH.HOME);
+  };
+
+  return {
+    myInfo,
+    myCyclesStat,
+    handleClickEdit,
+    handleClickLogout,
+  };
+};
+
+export default useProfile;

--- a/frontend/src/components/SuccessModal/index.tsx
+++ b/frontend/src/components/SuccessModal/index.tsx
@@ -1,32 +1,13 @@
+import useSuccessModal from './useSuccessModal';
 import Close from 'assets/close.svg';
-import { useEffect } from 'react';
-import { useReward } from 'react-rewards';
-import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { getEmoji } from 'utils/emoji';
 
-import usePostJoinChallenge from 'hooks/usePostJoinChallenge';
 import useThemeContext from 'hooks/useThemeContext';
 
 import { Button, FlexBox, ModalOverlay, Text, CheckCircles } from 'components';
 import { SuccessModalProps } from 'components/SuccessModal/type';
 
-import { CYCLE_SUCCESS_CRITERIA } from 'constants/domain';
-import { CLIENT_PATH } from 'constants/path';
-
-const getMessageByProgressCount = (progressCount: number) => {
-  switch (progressCount) {
-    case 1:
-      return '시작이 좋네요!';
-    case 2:
-      return '다 왔어요. 한 번만 더!';
-    case 3:
-      return '한 번 더 도전하기';
-
-    default:
-      break;
-  }
-};
 export const SuccessModal = ({
   handleCloseModal,
   cycleId,
@@ -36,102 +17,71 @@ export const SuccessModal = ({
   progressCount,
 }: SuccessModalProps) => {
   const themeContext = useThemeContext();
-  const navigate = useNavigate();
-  const { reward: confettiReward } = useReward('confettiRewardId', 'confetti');
-  const { reward: emojiReward } = useReward('emojiRewardId', 'emoji', {
-    emoji: [getEmoji(Number(challengeId))],
-  });
-
-  const postJoinChallengeSuccessCallback = () => {
-    navigate(CLIENT_PATH.CERT);
-    handleCloseModal();
-  };
-
-  const { joinChallenge } = usePostJoinChallenge({
+  const {
+    successMessage,
+    isChallengeComplete,
+    handleClickClose,
+    handleClickCheck,
+    handleClickRetry,
+  } = useSuccessModal({
+    handleCloseModal,
+    cycleId,
+    challengeName,
     challengeId,
-    successCallback: postJoinChallengeSuccessCallback,
+    progressCount,
   });
-
-  const handleCheckCertification = () => {
-    // TODO: 챌린지 상세보기 페이지로 이동
-    handleCloseModal();
-    navigate(`${CLIENT_PATH.CYCLE_DETAIL}/${cycleId}`);
-  };
-
-  const handleClickClose = () => {
-    handleCloseModal();
-    navigate(CLIENT_PATH.CERT);
-  };
-
-  const handleRetry = () => {
-    joinChallenge(challengeName);
-  };
-
-  const isChallengeComplete = progressCount === CYCLE_SUCCESS_CRITERIA;
-
-  useEffect(() => {
-    confettiReward();
-    emojiReward();
-  }, []);
 
   return (
-    <>
-      <ModalOverlay handleCloseModal={handleClickClose}>
-        <Wrapper
-          flexDirection="column"
-          alignItems="center"
-          justifyContent="center"
-          gap="1rem"
-        >
-          <CloseWrapper onClick={handleClickClose}>
-            <Close />
-          </CloseWrapper>
-          <Text color={themeContext.onSurface} size={70} fontWeight="normal">
-            {getEmoji(Number(challengeId))}
-            <span id="confettiRewardId" />
-            <span id="emojiRewardId" />
+    <ModalOverlay handleCloseModal={handleClickClose}>
+      <Wrapper
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        gap="1rem"
+      >
+        <CloseWrapper onClick={handleClickClose}>
+          <Close />
+        </CloseWrapper>
+        <Text color={themeContext.onSurface} size={70} fontWeight="normal">
+          {getEmoji(Number(challengeId))}
+          <span id="confettiRewardId" />
+          <span id="emojiRewardId" />
+        </Text>
+        <Text color={themeContext.onSurface} size={20} fontWeight="bold">
+          {challengeName}
+        </Text>
+        <Text color={themeContext.primary} size={20} fontWeight="bold">
+          {isChallengeComplete ? '🎉 챌린지 성공 🎉' : '오늘의 인증 완료'}
+        </Text>
+        <Text color={themeContext.onSurface} size={20} fontWeight="bold">
+          {successMessage}
+        </Text>
+        {isChallengeComplete ? (
+          <Text color={themeContext.disabled} size={16} fontWeight="normal">
+            해당 챌린지를 총 {successCount}회 성공하셨어요.
           </Text>
-          <Text color={themeContext.onSurface} size={20} fontWeight="bold">
-            {challengeName}
-          </Text>
-          <Text color={themeContext.primary} size={20} fontWeight="bold">
-            {isChallengeComplete ? '🎉 챌린지 성공 🎉' : '오늘의 인증 완료'}
-          </Text>
-          <Text color={themeContext.onSurface} size={20} fontWeight="bold">
-            {getMessageByProgressCount(progressCount)}
-          </Text>
-          {isChallengeComplete ? (
-            <Text color={themeContext.disabled} size={16} fontWeight="normal">
-              해당 챌린지를 총 {successCount}회 성공하셨어요.
-            </Text>
-          ) : (
-            <CheckCircles progressCount={progressCount} />
-          )}
+        ) : (
+          <CheckCircles progressCount={progressCount} />
+        )}
 
-          <FlexBox alignItems="center" gap="1rem">
-            {isChallengeComplete ? (
-              <>
-                <Button onClick={handleCheckCertification} size="medium" isActive={false}>
-                  기록 확인
-                </Button>
-                <Button onClick={handleRetry} size="medium" isActive={true}>
-                  재도전
-                </Button>
-              </>
-            ) : (
-              <Button
-                autoFocus
-                onClick={handleCheckCertification}
-                size="medium"
-                isActive={false}
-              >
+        <FlexBox alignItems="center" gap="1rem">
+          {isChallengeComplete ? (
+            <>
+              <Button onClick={handleClickCheck} size="medium" isActive={false}>
                 기록 확인
               </Button>
-            )}
-          </FlexBox>
-        </Wrapper>
-      </ModalOverlay>
-    </>
+              <Button onClick={handleClickRetry} size="medium" isActive={true}>
+                재도전
+              </Button>
+            </>
+          ) : (
+            <Button autoFocus onClick={handleClickCheck} size="medium" isActive={false}>
+              기록 확인
+            </Button>
+          )}
+        </FlexBox>
+      </Wrapper>
+    </ModalOverlay>
   );
 };
 

--- a/frontend/src/components/SuccessModal/type.ts
+++ b/frontend/src/components/SuccessModal/type.ts
@@ -7,3 +7,5 @@ export interface SuccessModalProps
   > {
   handleCloseModal: () => void;
 }
+
+export type UseSuccessModalProps = Omit<SuccessModalProps, 'successCount'>;

--- a/frontend/src/components/SuccessModal/useSuccessModal.ts
+++ b/frontend/src/components/SuccessModal/useSuccessModal.ts
@@ -1,0 +1,81 @@
+import { useEffect } from 'react';
+import { useReward } from 'react-rewards';
+import { useNavigate } from 'react-router-dom';
+import { getEmoji } from 'utils/emoji';
+
+import usePostJoinChallenge from 'hooks/usePostJoinChallenge';
+
+import { UseSuccessModalProps } from 'components/SuccessModal/type';
+
+import { CYCLE_SUCCESS_CRITERIA } from 'constants/domain';
+import { CLIENT_PATH } from 'constants/path';
+
+const getMessageByProgressCount = (progressCount: number) => {
+  switch (progressCount) {
+    case 1:
+      return '시작이 좋네요!';
+    case 2:
+      return '다 왔어요. 한 번만 더!';
+    case 3:
+      return '한 번 더 도전하기';
+
+    default:
+      break;
+  }
+};
+
+const useSuccessModal = ({
+  handleCloseModal,
+  cycleId,
+  challengeName,
+  challengeId,
+  progressCount,
+}: UseSuccessModalProps) => {
+  const navigate = useNavigate();
+  const { reward: confettiReward } = useReward('confettiRewardId', 'confetti');
+  const { reward: emojiReward } = useReward('emojiRewardId', 'emoji', {
+    emoji: [getEmoji(Number(challengeId))],
+  });
+
+  const postJoinChallengeSuccessCallback = () => {
+    navigate(CLIENT_PATH.CERT);
+    handleCloseModal();
+  };
+
+  const { joinChallenge } = usePostJoinChallenge({
+    challengeId,
+    successCallback: postJoinChallengeSuccessCallback,
+  });
+
+  const handleClickCheck = () => {
+    handleCloseModal();
+    navigate(`${CLIENT_PATH.CYCLE_DETAIL}/${cycleId}`);
+  };
+
+  const handleClickClose = () => {
+    handleCloseModal();
+    navigate(CLIENT_PATH.CERT);
+  };
+
+  const handleClickRetry = () => {
+    joinChallenge(challengeName);
+  };
+
+  const isChallengeComplete = progressCount === CYCLE_SUCCESS_CRITERIA;
+
+  const successMessage = getMessageByProgressCount(progressCount);
+
+  useEffect(() => {
+    confettiReward();
+    emojiReward();
+  }, []);
+  return {
+    successMessage,
+    isChallengeComplete,
+    handleClickClose,
+    handleClickCheck,
+    handleClickRetry,
+  };
+};
+
+export default useSuccessModal;

--- a/frontend/src/components/Timer/index.tsx
+++ b/frontend/src/components/Timer/index.tsx
@@ -1,5 +1,3 @@
-import styled from 'styled-components';
-
 import { FlexBox, Text } from 'components';
 import { TimerProps } from 'components/Timer/type';
 import { useTimer } from 'components/Timer/useTimer';

--- a/frontend/src/components/Title/index.tsx
+++ b/frontend/src/components/Title/index.tsx
@@ -1,5 +1,5 @@
+import useTitle from './useTitle';
 import { MdArrowBackIosNew } from 'react-icons/md';
-import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import useThemeContext from 'hooks/useThemeContext';
@@ -9,15 +9,7 @@ import { TitleProps } from 'components/Title/type';
 
 export const Title = ({ text, linkTo }: TitleProps) => {
   const themeContext = useThemeContext();
-  const navigate = useNavigate();
-  const backToPreviousPage = () => {
-    if (linkTo) {
-      navigate(linkTo);
-      return;
-    }
-
-    navigate(-1);
-  };
+  const { backToPreviousPage } = useTitle({ linkTo });
 
   return (
     <TitleWrapper flexDirection="row" justifyContent="center">

--- a/frontend/src/components/Title/type.ts
+++ b/frontend/src/components/Title/type.ts
@@ -2,3 +2,5 @@ export interface TitleProps {
   text: string;
   linkTo?: string;
 }
+
+export type UseTitleProps = Pick<TitleProps, 'linkTo'>;

--- a/frontend/src/components/Title/useTitle.ts
+++ b/frontend/src/components/Title/useTitle.ts
@@ -1,0 +1,17 @@
+import { UseTitleProps } from './type';
+import { useNavigate } from 'react-router-dom';
+
+const useTitle = ({ linkTo }: UseTitleProps) => {
+  const navigate = useNavigate();
+  const backToPreviousPage = () => {
+    if (linkTo) {
+      navigate(linkTo);
+      return;
+    }
+
+    navigate(-1);
+  };
+  return { backToPreviousPage };
+};
+
+export default useTitle;

--- a/frontend/src/components/UserWithdrawalModal/index.tsx
+++ b/frontend/src/components/UserWithdrawalModal/index.tsx
@@ -1,51 +1,19 @@
-import { useDeleteMyInfo } from 'apis';
-import { authApiClient } from 'apis/apiClient';
-import { MouseEventHandler } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useSetRecoilState } from 'recoil';
-import { isLoginState } from 'recoil/auth/atoms';
+import useUserWithdrawalModal from './useUserWithdrawalModal';
 import styled, { css } from 'styled-components';
 
-import useInput from 'hooks/useInput';
-import useSnackBar from 'hooks/useSnackBar';
 import useThemeContext from 'hooks/useThemeContext';
 
 import { Button, FlexBox, ModalOverlay, Text, Input } from 'components';
 import { UserWithdrawalModalProps } from 'components/UserWithdrawalModal/type';
-
-import { CLIENT_PATH } from 'constants/path';
 
 export const UserWithdrawalModal = ({
   email,
   handleCloseModal,
 }: UserWithdrawalModalProps) => {
   const themeContext = useThemeContext();
-  const navigate = useNavigate();
-  const renderSnackBar = useSnackBar();
-  const emailInput = useInput('');
-
-  const setIsLogin = useSetRecoilState(isLoginState);
-
-  const { isLoading: isLoadingDeleteMyInfo, mutate: deleteMyInfo } = useDeleteMyInfo({
-    onSuccess: () => {
-      renderSnackBar({
-        message:
-          '회원 정보를 성공적으로 삭제했습니다. 그동안 스모디를 이용해 주셔서 감사합니다.',
-        status: 'SUCCESS',
-      });
-
-      authApiClient.deleteAuth();
-      setIsLogin(false);
-
-      navigate(CLIENT_PATH.HOME);
-    },
-  });
-
-  const canWithdrawal = email === emailInput.value;
-
-  const handleClickUserWithdrawal: MouseEventHandler<HTMLButtonElement> = () => {
-    deleteMyInfo();
-  };
+  const { canWithdrawal, handleClickUserWithdrawal, emailInput } = useUserWithdrawalModal(
+    { email },
+  );
 
   return (
     <ModalOverlay handleCloseModal={handleCloseModal}>

--- a/frontend/src/components/UserWithdrawalModal/type.ts
+++ b/frontend/src/components/UserWithdrawalModal/type.ts
@@ -3,3 +3,5 @@ import { User } from 'commonType';
 export interface UserWithdrawalModalProps extends Pick<User, 'email'> {
   handleCloseModal: () => void;
 }
+
+export type UseUserWithdrawalModalProps = Pick<UserWithdrawalModalProps, 'email'>;

--- a/frontend/src/components/UserWithdrawalModal/useUserWithdrawalModal.ts
+++ b/frontend/src/components/UserWithdrawalModal/useUserWithdrawalModal.ts
@@ -1,0 +1,44 @@
+import { UseUserWithdrawalModalProps } from './type';
+import { useDeleteMyInfo } from 'apis';
+import { authApiClient } from 'apis/apiClient';
+import { MouseEventHandler } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
+import { isLoginState } from 'recoil/auth/atoms';
+
+import useInput from 'hooks/useInput';
+import useSnackBar from 'hooks/useSnackBar';
+
+import { CLIENT_PATH } from 'constants/path';
+
+const useUserWithdrawalModal = ({ email }: UseUserWithdrawalModalProps) => {
+  const navigate = useNavigate();
+  const renderSnackBar = useSnackBar();
+  const emailInput = useInput('');
+
+  const setIsLogin = useSetRecoilState(isLoginState);
+
+  const { mutate: deleteMyInfo } = useDeleteMyInfo({
+    onSuccess: () => {
+      renderSnackBar({
+        message:
+          '회원 정보를 성공적으로 삭제했습니다. 그동안 스모디를 이용해 주셔서 감사합니다.',
+        status: 'SUCCESS',
+      });
+
+      authApiClient.deleteAuth();
+      setIsLogin(false);
+
+      navigate(CLIENT_PATH.HOME);
+    },
+  });
+
+  const canWithdrawal = email === emailInput.value;
+
+  const handleClickUserWithdrawal: MouseEventHandler<HTMLButtonElement> = () => {
+    deleteMyInfo();
+  };
+  return { canWithdrawal, handleClickUserWithdrawal, emailInput };
+};
+
+export default useUserWithdrawalModal;

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -30,3 +30,4 @@ export * from 'components/CycleDetailItem';
 export * from 'components/CycleDetailList';
 export * from 'components/Title';
 export * from 'components/LoadingButton';
+export * from 'components/InfiniteScroll';

--- a/frontend/src/mocks/data.ts
+++ b/frontend/src/mocks/data.ts
@@ -330,6 +330,151 @@ export const mySuccessChallengeData = [
     challengeName: '일찍 잠자기',
     successCount: 100,
   },
+  {
+    challengeId: 5,
+    challengeName: '미라클 모닝',
+    successCount: 3,
+  },
+  {
+    challengeId: 6,
+    challengeName: '1일 1시간 공부',
+    successCount: 2,
+  },
+  {
+    challengeId: 7,
+    challengeName: '책읽기',
+    successCount: 1,
+  },
+  {
+    challengeId: 8,
+    challengeName: '일찍 잠자기',
+    successCount: 100,
+  },
+  {
+    challengeId: 9,
+    challengeName: '미라클 모닝',
+    successCount: 3,
+  },
+  {
+    challengeId: 10,
+    challengeName: '1일 1시간 공부',
+    successCount: 2,
+  },
+  {
+    challengeId: 11,
+    challengeName: '책읽기',
+    successCount: 1,
+  },
+  {
+    challengeId: 12,
+    challengeName: '일찍 잠자기',
+    successCount: 100,
+  },
+  {
+    challengeId: 13,
+    challengeName: '일찍 잠자기',
+    successCount: 100,
+  },
+  {
+    challengeId: 14,
+    challengeName: '미라클 모닝',
+    successCount: 3,
+  },
+  {
+    challengeId: 15,
+    challengeName: '1일 1시간 공부',
+    successCount: 2,
+  },
+  {
+    challengeId: 16,
+    challengeName: '책읽기',
+    successCount: 1,
+  },
+  {
+    challengeId: 17,
+    challengeName: '일찍 잠자기',
+    successCount: 100,
+  },
+  {
+    challengeId: 18,
+    challengeName: '미라클 모닝',
+    successCount: 3,
+  },
+  {
+    challengeId: 19,
+    challengeName: '1일 1시간 공부',
+    successCount: 2,
+  },
+  {
+    challengeId: 20,
+    challengeName: '책읽기',
+    successCount: 1,
+  },
+  {
+    challengeId: 21,
+    challengeName: '일찍 잠자기',
+    successCount: 100,
+  },
+  {
+    challengeId: 22,
+    challengeName: '미라클 모닝',
+    successCount: 3,
+  },
+  {
+    challengeId: 23,
+    challengeName: '1일 1시간 공부',
+    successCount: 2,
+  },
+  {
+    challengeId: 24,
+    challengeName: '책읽기',
+    successCount: 1,
+  },
+  {
+    challengeId: 25,
+    challengeName: '일찍 잠자기',
+    successCount: 100,
+  },
+  {
+    challengeId: 26,
+    challengeName: '미라클 모닝',
+    successCount: 3,
+  },
+  {
+    challengeId: 27,
+    challengeName: '1일 1시간 공부',
+    successCount: 2,
+  },
+  {
+    challengeId: 28,
+    challengeName: '책읽기',
+    successCount: 1,
+  },
+  {
+    challengeId: 29,
+    challengeName: '일찍 잠자기',
+    successCount: 100,
+  },
+  {
+    challengeId: 30,
+    challengeName: '미라클 모닝',
+    successCount: 3,
+  },
+  {
+    challengeId: 31,
+    challengeName: '1일 1시간 공부',
+    successCount: 2,
+  },
+  {
+    challengeId: 32,
+    challengeName: '책읽기',
+    successCount: 1,
+  },
+  {
+    challengeId: 33,
+    challengeName: '일찍 잠자기',
+    successCount: 100,
+  },
 ];
 
 export const userData = {

--- a/frontend/src/pages/CertFormPage/index.tsx
+++ b/frontend/src/pages/CertFormPage/index.tsx
@@ -1,20 +1,9 @@
-import { usePostCycleProgress } from 'apis';
+import useCertFormPage from './useCertFormPage';
 import Plus from 'assets/plus.svg';
-import { useState, useMemo, FormEventHandler } from 'react';
-import { useLocation, Navigate } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
-import { isDarkState } from 'recoil/darkMode/atoms';
 import styled, { css } from 'styled-components';
 import { getEmoji } from 'utils/emoji';
 
-import useImageInput from 'hooks/useImageInput';
-import useThemeContext from 'hooks/useThemeContext';
-
-import {
-  CertImageWrapperProps,
-  TextAreaProps,
-  CertFormPageLocationState,
-} from 'pages/CertFormPage/type';
+import { CertImageWrapperProps, TextAreaProps } from 'pages/CertFormPage/type';
 
 import {
   FlexBox,
@@ -28,56 +17,27 @@ import { SuccessModal } from 'components/SuccessModal';
 
 import { CLIENT_PATH } from 'constants/path';
 
-const FORM_DATA_IMAGE_NAME = 'progressImage';
-
 const CertFormPage = () => {
-  const isDark = useRecoilValue(isDarkState);
-  const themeContext = useThemeContext();
-  const [description, setDescription] = useState('');
-  const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
-
   const {
+    themeContext,
+    isDark,
+    cycleId,
+    challengeId,
+    challengeName,
+    successCount,
+    progressCount,
+    isButtonDisabled,
+    isLoadingPost,
+    isSuccessPost,
+    isSuccessModalOpen,
+    description,
     previewImageUrl,
     handleImageInputButtonClick,
     renderImageInput,
-    hasImageFormData,
-    isImageLoading,
-    formData,
-  } = useImageInput(FORM_DATA_IMAGE_NAME);
-  const isButtonDisabled = useMemo(
-    () => isImageLoading || !hasImageFormData,
-    [isImageLoading, formData],
-  );
-
-  const {
-    mutate: postCycleProgress,
-    isLoading: isLoadingPost,
-    isSuccess: isSuccessPost,
-  } = usePostCycleProgress({
-    onSuccess: () => {
-      setIsSuccessModalOpen(true);
-    },
-  });
-
-  const location = useLocation();
-
-  const { cycleId, challengeId, challengeName, successCount, progressCount } =
-    location.state as CertFormPageLocationState;
-
-  const handleSubmitCert: FormEventHandler<HTMLFormElement> = (event) => {
-    event.preventDefault();
-
-    formData.append(
-      'description',
-      description.trim() || `${challengeName}챌린지 ${progressCount + 1}번째 완료`,
-    );
-
-    postCycleProgress({ cycleId, formData });
-  };
-
-  const handleCloseModal = () => {
-    setIsSuccessModalOpen(false);
-  };
+    handleSubmitCert,
+    handleCloseModal,
+    handleChangeDescription,
+  } = useCertFormPage();
 
   return (
     <FlexBox flexDirection="column" alignItems="center">
@@ -141,9 +101,7 @@ const CertFormPage = () => {
             rows={5}
             maxLength={254}
             value={description}
-            onChange={(event) => {
-              setDescription(event.target.value);
-            }}
+            onChange={handleChangeDescription}
             isDark={isDark}
           />
           <TextLength

--- a/frontend/src/pages/CertFormPage/useCertFormPage.ts
+++ b/frontend/src/pages/CertFormPage/useCertFormPage.ts
@@ -1,0 +1,90 @@
+import { usePostCycleProgress } from 'apis';
+import { useState, useMemo, FormEventHandler, ChangeEvent } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import { isDarkState } from 'recoil/darkMode/atoms';
+
+import useImageInput from 'hooks/useImageInput';
+import useThemeContext from 'hooks/useThemeContext';
+
+import { CertFormPageLocationState } from 'pages/CertFormPage/type';
+
+const FORM_DATA_IMAGE_NAME = 'progressImage';
+
+const useCertFormPage = () => {
+  const isDark = useRecoilValue(isDarkState);
+  const themeContext = useThemeContext();
+  const [description, setDescription] = useState('');
+  const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
+
+  const {
+    previewImageUrl,
+    handleImageInputButtonClick,
+    renderImageInput,
+    hasImageFormData,
+    isImageLoading,
+    formData,
+  } = useImageInput(FORM_DATA_IMAGE_NAME);
+
+  const isButtonDisabled = useMemo(
+    () => isImageLoading || !hasImageFormData,
+    [isImageLoading, formData],
+  );
+
+  const {
+    mutate: postCycleProgress,
+    isLoading: isLoadingPost,
+    isSuccess: isSuccessPost,
+  } = usePostCycleProgress({
+    onSuccess: () => {
+      setIsSuccessModalOpen(true);
+    },
+  });
+
+  const { state } = useLocation();
+
+  const { cycleId, challengeId, challengeName, successCount, progressCount } =
+    state as CertFormPageLocationState;
+
+  const handleSubmitCert: FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault();
+
+    formData.append(
+      'description',
+      description.trim() || `${challengeName}챌린지 ${progressCount + 1}번째 완료`,
+    );
+
+    postCycleProgress({ cycleId, formData });
+  };
+
+  const handleCloseModal = () => {
+    setIsSuccessModalOpen(false);
+  };
+
+  const handleChangeDescription = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setDescription(event.target.value);
+  };
+
+  return {
+    themeContext,
+    isDark,
+    cycleId,
+    challengeId,
+    challengeName,
+    successCount,
+    progressCount,
+    isButtonDisabled,
+    isLoadingPost,
+    isSuccessPost,
+    isSuccessModalOpen,
+    description,
+    previewImageUrl,
+    handleImageInputButtonClick,
+    renderImageInput,
+    handleSubmitCert,
+    handleCloseModal,
+    handleChangeDescription,
+  };
+};
+
+export default useCertFormPage;

--- a/frontend/src/pages/CertPage/index.tsx
+++ b/frontend/src/pages/CertPage/index.tsx
@@ -1,4 +1,4 @@
-import { useGetMyCyclesInProgress } from 'apis';
+import useCertPage from './useCertPage';
 import styled, { css } from 'styled-components';
 
 import { EmptyContent, CertItem } from 'components';
@@ -6,11 +6,9 @@ import { EmptyContent, CertItem } from 'components';
 import { CLIENT_PATH } from 'constants/path';
 
 const CertPage = () => {
-  const { data } = useGetMyCyclesInProgress({
-    refetchOnWindowFocus: false,
-  });
+  const { cycles } = useCertPage();
 
-  if (data?.data.length === 0) {
+  if (typeof cycles === 'undefined') {
     return (
       <EmptyContent
         title="도전 중인 챌린지가 없습니다 :)"
@@ -23,7 +21,7 @@ const CertPage = () => {
 
   return (
     <Wrapper>
-      {data?.data.map((cycle) => (
+      {cycles.map((cycle) => (
         <CertItem key={cycle.cycleId} {...cycle} />
       ))}
     </Wrapper>

--- a/frontend/src/pages/CertPage/useCertPage.ts
+++ b/frontend/src/pages/CertPage/useCertPage.ts
@@ -1,0 +1,13 @@
+import { useGetMyCyclesInProgress } from 'apis';
+
+const useCertPage = () => {
+  const { data } = useGetMyCyclesInProgress({
+    refetchOnWindowFocus: false,
+  });
+
+  const cycles = data?.data;
+
+  return { cycles };
+};
+
+export default useCertPage;

--- a/frontend/src/pages/ChallengeDetailPage/index.tsx
+++ b/frontend/src/pages/ChallengeDetailPage/index.tsx
@@ -1,11 +1,6 @@
-import { useGetChallengeById } from 'apis';
-import { queryKeys } from 'apis/constants';
-import { useQueryClient } from 'react-query';
-import { useParams } from 'react-router-dom';
+import useChallengeDetailPage from './useChallengeDetailPage';
 import styled from 'styled-components';
-import { getEmoji } from 'utils/emoji';
 
-import usePostJoinChallenge from 'hooks/usePostJoinChallenge';
 import useThemeContext from 'hooks/useThemeContext';
 
 import { ChallengeExplanationTextProps } from 'pages/ChallengeDetailPage/type';
@@ -16,22 +11,7 @@ import { CLIENT_PATH } from 'constants/path';
 
 const ChallengeDetailPage = () => {
   const themeContext = useThemeContext();
-  const queryClient = useQueryClient();
-  const { challengeId } = useParams();
-
-  const { data } = useGetChallengeById(
-    { challengeId: Number(challengeId) },
-    {
-      refetchOnWindowFocus: false,
-    },
-  );
-
-  const { joinChallenge } = usePostJoinChallenge({
-    challengeId: Number(challengeId),
-    successCallback: () => {
-      queryClient.invalidateQueries(queryKeys.getChallengeById);
-    },
-  });
+  const { data, joinChallenge, emoji } = useChallengeDetailPage();
 
   if (typeof data === 'undefined' || typeof data.data === 'undefined') {
     return null;
@@ -57,7 +37,7 @@ const ChallengeDetailPage = () => {
           </ChallengeExplanationText>
         </FlexBox>
         <ThumbnailWrapper size="medium" bgColor="#FED6D6">
-          {getEmoji(Number(challengeId))}
+          {emoji}
         </ThumbnailWrapper>
       </ChallengeDetailWrapper>
       <FixedButton

--- a/frontend/src/pages/ChallengeDetailPage/useChallengeDetailPage.ts
+++ b/frontend/src/pages/ChallengeDetailPage/useChallengeDetailPage.ts
@@ -1,0 +1,31 @@
+import { useGetChallengeById } from 'apis';
+import { queryKeys } from 'apis/constants';
+import { useQueryClient } from 'react-query';
+import { useParams } from 'react-router-dom';
+import { getEmoji } from 'utils/emoji';
+
+import usePostJoinChallenge from 'hooks/usePostJoinChallenge';
+
+const useChallengeDetailPage = () => {
+  const queryClient = useQueryClient();
+  const { challengeId } = useParams();
+  const emoji = getEmoji(Number(challengeId));
+
+  const { data } = useGetChallengeById(
+    { challengeId: Number(challengeId) },
+    {
+      refetchOnWindowFocus: false,
+    },
+  );
+
+  const { joinChallenge } = usePostJoinChallenge({
+    challengeId: Number(challengeId),
+    successCallback: () => {
+      queryClient.invalidateQueries(queryKeys.getChallengeById);
+    },
+  });
+
+  return { data, joinChallenge, emoji };
+};
+
+export default useChallengeDetailPage;

--- a/frontend/src/pages/CycleDetailPage/index.tsx
+++ b/frontend/src/pages/CycleDetailPage/index.tsx
@@ -1,5 +1,4 @@
-import { useGetCycleById } from 'apis';
-import { useParams } from 'react-router-dom';
+import useCycleDetailPage from './useCycleDetailPage';
 import styled from 'styled-components';
 import { parseTime } from 'utils';
 import { getEmoji } from 'utils/emoji';
@@ -18,14 +17,8 @@ import {
 import { CLIENT_PATH } from 'constants/path';
 
 const CycleDetailPage = () => {
-  const { cycleId } = useParams();
   const themeContext = useThemeContext();
-  const { data } = useGetCycleById(
-    { cycleId: Number(cycleId) },
-    {
-      refetchOnWindowFocus: false,
-    },
-  );
+  const data = useCycleDetailPage();
 
   if (typeof data === 'undefined') {
     return <LoadingSpinner />;

--- a/frontend/src/pages/CycleDetailPage/index.tsx
+++ b/frontend/src/pages/CycleDetailPage/index.tsx
@@ -18,13 +18,13 @@ import { CLIENT_PATH } from 'constants/path';
 
 const CycleDetailPage = () => {
   const themeContext = useThemeContext();
-  const data = useCycleDetailPage();
+  const cycleDetailData = useCycleDetailPage();
 
-  if (typeof data === 'undefined') {
-    return <LoadingSpinner />;
+  if (typeof cycleDetailData === 'undefined') {
+    return null;
   }
 
-  const { challengeId, challengeName, startTime, cycleDetails } = data.data;
+  const { challengeId, challengeName, startTime, cycleDetails } = cycleDetailData.data;
   const { year, month, date } = parseTime(startTime);
 
   return (

--- a/frontend/src/pages/CycleDetailPage/useCycleDetailPage.ts
+++ b/frontend/src/pages/CycleDetailPage/useCycleDetailPage.ts
@@ -3,14 +3,14 @@ import { useParams } from 'react-router-dom';
 
 const useCycleDetailPage = () => {
   const { cycleId } = useParams();
-  const { data } = useGetCycleById(
+  const { data: cycleDetailData } = useGetCycleById(
     { cycleId: Number(cycleId) },
     {
       refetchOnWindowFocus: false,
     },
   );
 
-  return data;
+  return cycleDetailData;
 };
 
 export default useCycleDetailPage;

--- a/frontend/src/pages/CycleDetailPage/useCycleDetailPage.ts
+++ b/frontend/src/pages/CycleDetailPage/useCycleDetailPage.ts
@@ -1,0 +1,16 @@
+import { useGetCycleById } from 'apis';
+import { useParams } from 'react-router-dom';
+
+const useCycleDetailPage = () => {
+  const { cycleId } = useParams();
+  const { data } = useGetCycleById(
+    { cycleId: Number(cycleId) },
+    {
+      refetchOnWindowFocus: false,
+    },
+  );
+
+  return data;
+};
+
+export default useCycleDetailPage;

--- a/frontend/src/pages/SearchPage/index.tsx
+++ b/frontend/src/pages/SearchPage/index.tsx
@@ -1,7 +1,31 @@
-import { ChallengeList } from 'components';
+import { useSearchPage } from 'pages/SearchPage/useSearchPage';
+
+import { LoadingSpinner, ChallengeItem, FlexBox, InfiniteScroll } from 'components';
 
 const SearchPage = () => {
-  return <ChallengeList />;
+  const { isFetching, challengeInfiniteData, hasNextPage, fetchNextPage } =
+    useSearchPage();
+
+  return (
+    <FlexBox flexDirection="column">
+      <InfiniteScroll
+        loadMore={fetchNextPage}
+        hasMore={hasNextPage}
+        isFetching={isFetching}
+        loader={<LoadingSpinner />}
+      >
+        <FlexBox as="ul" flexDirection="column" gap="27px">
+          {challengeInfiniteData?.pages.map((page) =>
+            page?.data.map((challengeInfo) => (
+              <li key={challengeInfo.challengeId}>
+                <ChallengeItem {...challengeInfo} />
+              </li>
+            )),
+          )}
+        </FlexBox>
+      </InfiniteScroll>
+    </FlexBox>
+  );
 };
 
 export default SearchPage;

--- a/frontend/src/pages/SearchPage/useSearchPage.ts
+++ b/frontend/src/pages/SearchPage/useSearchPage.ts
@@ -1,0 +1,19 @@
+import { useGetAllChallenges } from 'apis';
+
+export const useSearchPage = () => {
+  const {
+    isFetching,
+    data: challengeInfiniteData,
+    hasNextPage,
+    fetchNextPage,
+  } = useGetAllChallenges({
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    isFetching,
+    challengeInfiniteData,
+    hasNextPage,
+    fetchNextPage,
+  };
+};


### PR DESCRIPTION
close #126 
# custom hook 분리
## Pages
- ChallengeDetailPage
- CycleDetailPage
## Components
- CardGridContainer
- CertItem
- ChallengeItem

# Component 분리
- CheckCircles

# 단순 코드 리팩터링
- CycleDetailList