### PR TITLE
fix: ios에서 Notification Api가 없음에 따른 에러 해결

### DIFF
--- a/frontend/src/pushStatus.ts
+++ b/frontend/src/pushStatus.ts
@@ -14,9 +14,3 @@ export const pushStatus: PushStatus = {
   pushSubscription: null,
   notificationPermission: isSupported() && Notification.permission,
 };
-
-// if (isSupported()) {
-//   const pushStatus.notificationPermission = Notification.permission;
-// }
-
-// console.log('isSupported', isSupported);

--- a/frontend/src/pushStatus.ts
+++ b/frontend/src/pushStatus.ts
@@ -2,12 +2,21 @@ type PushStatus = {
   pushSupport: boolean;
   serviceWorkerRegistration: ServiceWorkerRegistration | null;
   pushSubscription: PushSubscription | null;
-  notificationPermission: 'granted' | 'default' | 'denied';
+  notificationPermission: 'granted' | 'default' | 'denied' | false;
 };
+
+const isSupported = () =>
+  'Notification' in window && 'serviceWorker' in navigator && 'PushManager' in window;
 
 export const pushStatus: PushStatus = {
   pushSupport: false,
   serviceWorkerRegistration: null,
   pushSubscription: null,
-  notificationPermission: Notification.permission,
+  notificationPermission: isSupported() && Notification.permission,
 };
+
+// if (isSupported()) {
+//   const pushStatus.notificationPermission = Notification.permission;
+// }
+
+// console.log('isSupported', isSupported);


### PR DESCRIPTION
close #267 
다음 함수의 반환값이 false이면 Notification 객체를 호출하지 않도록 변경
```javascript
const isSupported = () =>
  'Notification' in window && 'serviceWorker' in navigator && 'PushManager' in window;
```