### PR TITLE
fix: (fe) 도전 중인 챌린지가 없을 때 CertPage에 EmptyContent 렌더링

### DIFF
--- a/frontend/src/pages/CertPage/index.tsx
+++ b/frontend/src/pages/CertPage/index.tsx
@@ -9,6 +9,10 @@ const CertPage = () => {
   const { cycles } = useCertPage();
 
   if (typeof cycles === 'undefined') {
+    return null;
+  }
+
+  if (cycles.length === 0) {
     return (
       <EmptyContent
         title="도전 중인 챌린지가 없습니다 :)"


### PR DESCRIPTION
- CertPage에서 도전 중인 챌린지가 없을 때 빈 화면 대신 EmptyContent 컴포넌트를 렌더링하도록 수정

<img width="895" alt="image" src="https://user-images.githubusercontent.com/52148907/184471393-b7c5e720-09f3-4cc9-9e39-636574c86aa6.png">
