### PR TITLE
design: (fe) challengeName을 underline으로 표시

### DIFF
--- a/frontend/src/components/CustomCycleTimeBottomSheet/index.tsx
+++ b/frontend/src/components/CustomCycleTimeBottomSheet/index.tsx
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components';
 
 import useThemeContext from 'hooks/useThemeContext';
 
-import { BottomSheet, Button, Text, FlexBox } from 'components';
+import { BottomSheet, Button, Text, FlexBox, UnderLineText } from 'components';
 
 const selectTime = [
   '0:00',
@@ -60,11 +60,16 @@ export const CustomCycleTimeBottomSheet = ({
           </TipText>
           <StartInfoWrapper>
             <div>
-              <Text size={20} fontWeight="bold" color={themeContext.primary}>
-                {challengeName}&nbsp;
-              </Text>
+              <UnderLineText
+                fontSize={20}
+                fontWeight="bold"
+                fontColor={themeContext.onSurface}
+                underLineColor={themeContext.primary}
+              >
+                {challengeName}
+              </UnderLineText>
               <Text size={20} fontWeight="bold" color={themeContext.onSurface}>
-                챌린지&nbsp;
+                &nbsp;챌린지&nbsp;
               </Text>
             </div>
             <FlexBox alignItems="center">
@@ -147,7 +152,7 @@ const TipText = styled(Text)`
 
 const StartInfoWrapper = styled.div`
   div,
-  ${Text}, ${Button} {
+  ${Text}, ${Button}, ${UnderLineText} {
     display: inline-block;
     height: 34px;
     line-height: 34px;

--- a/frontend/src/components/UnderLineText/index.tsx
+++ b/frontend/src/components/UnderLineText/index.tsx
@@ -22,7 +22,7 @@ export const UnderLineText = styled.p<UnderLineTextProps>`
       display: block;
       position: absolute;
       left: 0;
-      bottom: 0;
+      bottom: 4px;
       width: 100%;
       height: ${fontSizeMapper[fontSize ?? 16] * 0.4}rem;
       background-color: ${underLineColor};


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/70249108/184783771-fc4c7dc2-02b8-4b1b-9009-8b3fffd0f97f.png)
![image](https://user-images.githubusercontent.com/70249108/184783714-46ed1c21-2223-4450-b6cb-49942abce2af.png)

시작 시간 선택 bottom sheet에서 챌린지 이름을 나타내는 ui 변경