### PR TITLE
fix: 프로필 편집 완료 후 refetch되지 않던 문제 해결

### DIFF
--- a/frontend/src/apis/oAuthApi/type.ts
+++ b/frontend/src/apis/oAuthApi/type.ts
@@ -6,7 +6,7 @@ export interface GetTokenGoogleResponse {
 
 export type GetMyInfoResponse = User;
 
-export type PatchMyInfoProps = Pick<User, 'nickname' | 'introduction' | 'picture'>;
+export type PatchMyInfoProps = Pick<User, 'nickname' | 'introduction'>;
 
 export interface PostProfileImageProps {
   formData: FormData;


### PR DESCRIPTION
close #325 

refetch 문제는 해결했으나, 다음과 같은 이슈를 확인했습니다.

`프로필 이미지(POST)`와 `닉네임과 자기소개(PATCH)` 수정 요청을 함께 보내면, 
성공 응답은 다 오지만,
refetch한 프로필 정보에는 수정된 `닉네임과 자기소개`이 반영되어 있지 않습니다.

백엔드 동시성 문제로 추측됩니다. 관련해서 이슈를 만들겠습니다.