### PR TITLE
feat: web-push 알림 받으면 setAppBadge하도록 서비스워커 통신 활성화

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -7,7 +7,7 @@
   "orientation": "any",
   "scope": "/",
   "short_name": "Smody",
-  "start_url": "/",
+  "start_url": "/home",
   "theme_color": "#7c61ff",
   "categories": [],
   "screenshots": [],

--- a/frontend/public/pushServiceWorker.js
+++ b/frontend/public/pushServiceWorker.js
@@ -1,7 +1,14 @@
+const broadcast = new BroadcastChannel('push-channel');
+
+self.addEventListener('install', (event) => {});
+
+self.addEventListener('activate', (event) => {});
+
+self.addEventListener('fetch', (event) => {});
+
 /**
  * 알림 관련 코드
  */
-
 self.addEventListener('push', (event) => {
   const data = event.data.json();
 
@@ -30,6 +37,8 @@ self.addEventListener('push', (event) => {
   };
 
   event.waitUntil(self.registration.showNotification(title, options));
+
+  broadcast.postMessage({ message: data.message });
 });
 
 self.addEventListener('notificationclick', (event) => {


### PR DESCRIPTION
close #285 

서비스 워커는 워커 맥락에서 실행되기 때문에 DOM에 접근할 수 없다.
따라서 메인스레드와 Web Worker는 메시지 방식으로 서로 통신하며 데이터를 주고받는다.

이 둘이 통신하기 위해서는 특별한 방법이 필요하다. 

리서치한 결과, 이번 프로젝트에서는 BroadcastChannel API 를 사용했다.

이를 이용하여 서비스워커에서 push 이벤트 감지하면 app 내에서 setAppBadge 메서드를 실행하도록 했다.