### PR TITLE
fix : (be) 피드 조회 시 cursorId가 0으로 올 때 발생하는 에러 처리

### DIFF
--- a/backend/smody/src/main/java/com/woowacourse/smody/service/FeedQueryService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/service/FeedQueryService.java
@@ -5,15 +5,15 @@ import com.woowacourse.smody.domain.PagingParams;
 import com.woowacourse.smody.dto.FeedResponse;
 import com.woowacourse.smody.repository.FeedRepository;
 import com.woowacourse.smody.repository.SortSelection;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -31,15 +31,16 @@ public class FeedQueryService {
     }
 
     public List<FeedResponse> findAll(PagingParams pagingParams) {
-
         Pageable pageRequest = toPageRequest(pagingParams.getSize(), pagingParams.getSort());
+        Long cursorId = pagingParams.getDefaultCursorId();
+        Optional<Feed> findFeed = feedRepository.findByCycleDetailId(cursorId);
 
-        if (pagingParams.getCursorId() == null) {
+        if (findFeed.isEmpty()) {
             List<Feed> feeds = feedRepository.findAll(0L, LocalDateTime.now(), pageRequest);
             return convertFeedResponse(feeds);
         }
 
-        Feed feed = feedService.search(pagingParams.getCursorId());
+        Feed feed = findFeed.get();
         List<Feed> feeds = feedRepository.findAll(feed.getCycleDetailId(), feed.getProgressTime(),
                 pageRequest);
         return convertFeedResponse(feeds);


### PR DESCRIPTION
- before: CycleDetail 테이블에 cursorId에 맞는 id가 없을 경우 404 에러를 반환
- after: 피드 조회 시 id가 없어도 빈 리스트를 반환하도록 수정