### PR TITLE
feat: 페이지 이동시 스크롤을 상단으로 초기화

### DIFF
--- a/frontend/src/Layout/index.tsx
+++ b/frontend/src/Layout/index.tsx
@@ -15,6 +15,7 @@ import {
   LoadingSpinner,
   Navbar,
   SnackBar,
+  ScrollToTop,
 } from 'components';
 
 import { CLIENT_PATH } from 'constants/path';
@@ -60,7 +61,9 @@ export const Layout = () => {
           )}
         >
           <Suspense fallback={<LoadingSpinner />}>
-            <Outlet />
+            <ScrollToTop pathname={pathname}>
+              <Outlet />
+            </ScrollToTop>
           </Suspense>
         </ErrorBoundary>
       </OutletWrapper>
@@ -70,9 +73,7 @@ export const Layout = () => {
   );
 };
 
-const Wrapper = styled.div`
-  /* min-width: 400px; */
-`;
+const Wrapper = styled.div``;
 
 const OutletWrapper = styled(FlexBox)<OutletWrapperProps>`
   ${({ bgColor, horizontalPadding }) => css`

--- a/frontend/src/components/ScrollToTop/index.tsx
+++ b/frontend/src/components/ScrollToTop/index.tsx
@@ -1,0 +1,22 @@
+import { ScrollToTopProps } from './type';
+import React from 'react';
+
+export class ScrollToTop extends React.Component<ScrollToTopProps> {
+  constructor(props: ScrollToTopProps) {
+    super(props);
+  }
+
+  componentDidUpdate(prevProps: ScrollToTopProps) {
+    const { pathname: prevPathname } = prevProps;
+    const { pathname: currentPathname } = this.props;
+
+    // 컴포넌트 업데이트 시 페이지 이동인지 확인
+    if (prevPathname !== currentPathname) {
+      window.scrollTo(0, 0);
+    }
+  }
+
+  render() {
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/ScrollToTop/type.ts
+++ b/frontend/src/components/ScrollToTop/type.ts
@@ -1,0 +1,6 @@
+import { ReactNode } from 'react';
+
+export interface ScrollToTopProps {
+  pathname: string;
+  children: ReactNode;
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -53,3 +53,4 @@ export * from 'components/ErrorFallbackMain';
 export * from 'components/ErrorFallbackLoginButton';
 export * from 'components/ErrorFallbackSubscriptionButton';
 export * from 'components/ErrorFallbackNotificationMessage';
+export * from 'components/ScrollToTop';


### PR DESCRIPTION
close #367 
Co-authored-by: Woo seung <woose28@users.noreply.github.com>


> 참고 https://kimchanjung.github.io/programming/2020/06/25/react-scroll-top/