### PR TITLE
fix: (fe) 피드와 댓글 UI에서 텍스트 넘치는 이슈 해결

### DIFF
--- a/frontend/src/components/CommentItem/index.tsx
+++ b/frontend/src/components/CommentItem/index.tsx
@@ -48,7 +48,7 @@ export const CommentItem = ({
         )}
       </FlexBox>
       <ContentWrapper>
-        <Content size={16} color={themeContext.mainText} style={{ whiteSpace: 'pre' }}>
+        <Content size={16} color={themeContext.mainText}>
           {content}
         </Content>
       </ContentWrapper>
@@ -93,6 +93,7 @@ const ContentWrapper = styled(FlexBox)`
 const Content = styled(Text)`
   ${({ theme }) => css`
     color: ${theme.onBackground};
+    white-space: pre-wrap;
     word-wrap: break-word;
     word-break: break-all;
   `}

--- a/frontend/src/components/FeedItem/index.tsx
+++ b/frontend/src/components/FeedItem/index.tsx
@@ -104,6 +104,9 @@ const ProgressImg = styled.img`
 
 const MainText = styled(Text)`
   align-self: flex-start;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  word-break: break-all;
 `;
 
 const CommentCount = styled(Text)`

--- a/frontend/src/mocks/data.ts
+++ b/frontend/src/mocks/data.ts
@@ -825,7 +825,8 @@ export const feedData = [
       'https://cdn.pixabay.com/photo/2022/08/03/04/41/beech-leaves-7361863_1280.jpg',
     nickname: '유저1',
     progressImage: 'https://i.ibb.co/mJwjFq1/progress-Image.png',
-    description: '바다가 너무 예쁘네요^_^',
+    description:
+      '바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[0].challengeId,
     challengeName: challengeData[0].challengeName,
@@ -838,7 +839,8 @@ export const feedData = [
     nickname: userData.nickname,
     progressImage:
       'https://cdn.pixabay.com/photo/2019/07/21/13/42/nature-conservation-4352793_1280.jpg',
-    description: '오늘 날씨가 너무 좋아요~!',
+    description:
+      'Moo https://www.acmicpc.net/problem/5904 https://github.com/tonic523/Algorithm/tree/main/%EB%B6%84%ED%95%A0%20%EC%A0%95%EB%B3%B5/Moo%20%EA%B2%8C%EC%9E%84',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[0].challengeId,
     challengeName: challengeData[0].challengeName,


### PR DESCRIPTION
cloes #381 

# 이슈 상황
## 이슈 해결 전
<img width="775" alt="이슈 해결 전" src="https://user-images.githubusercontent.com/52148907/188567199-c92671e4-c495-4ac5-8aaa-b1918d342401.png">

## 이슈 해결 후
<img width="775" alt="이슈 해결 후" src="https://user-images.githubusercontent.com/52148907/188567212-d46cf7cc-4c81-4364-ab78-78a7203608d9.png">

# 해결 방법
FeedItem 컴포넌트의 피드 description(내용)을 보여주는 태그의 스타일에 아래의 속성과 값 적용
- white-space: pre-wrap;
- word-wrap: break-word;
- word-break: break-all;

추가적으로 CommentItem 컴포넌트의 content(내용)을 보여주는 태그의 스타일에 `white-space: pre-wrap` 적용

# 참고 자료
[MDN - white space](https://developer.mozilla.org/ko/docs/Web/CSS/white-space)