### PR TITLE
fix: (fe) 피드 상세 페이지에서 챌린지 이름 관련 이슈 해결

### DIFF
--- a/frontend/src/components/CommentInput/index.tsx
+++ b/frontend/src/components/CommentInput/index.tsx
@@ -93,6 +93,7 @@ const CommentInputElement = styled.textarea`
 
 const WriteButton = styled.button<WriteButtonProps>`
   ${({ theme, isVisible }) => css`
+    min-width: 50px;
     height: 20px;
     padding: 0 0.625rem;
     font-size: 0.75rem;

--- a/frontend/src/components/CommentInput/index.tsx
+++ b/frontend/src/components/CommentInput/index.tsx
@@ -93,9 +93,9 @@ const CommentInputElement = styled.textarea`
 
 const WriteButton = styled.button<WriteButtonProps>`
   ${({ theme, isVisible }) => css`
-    min-width: 50px;
+    min-width: 40px;
     height: 20px;
-    padding: 0 0.625rem;
+    padding: 0;
     font-size: 0.75rem;
     font-weight: bold;
     color: ${theme.primary};

--- a/frontend/src/components/CycleDetailItem/index.tsx
+++ b/frontend/src/components/CycleDetailItem/index.tsx
@@ -26,7 +26,7 @@ export const CycleDetailItem = ({
             <Text size={14} color={themeContext.mainText}>
               {year}년 {month}월 {date}일 {hours}:{minutes}
             </Text>
-            <Text color={themeContext.onSurface}>{description}</Text>
+            <MainText color={themeContext.onSurface}>{description}</MainText>
           </FlexBox>
         </DetailContents>
       </FlexBox>
@@ -88,4 +88,10 @@ const DetailContents = styled.div`
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+`;
+
+const MainText = styled(Text)`
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  word-break: break-all;
 `;

--- a/frontend/src/components/FeedItem/index.tsx
+++ b/frontend/src/components/FeedItem/index.tsx
@@ -17,6 +17,7 @@ export const FeedItem = ({
   challengeName,
   commentCount,
   isClickable = true,
+  isShowBriefChallengeName = true,
 }: FeedItemProps) => {
   const themeContext = useThemeContext();
 
@@ -30,27 +31,25 @@ export const FeedItem = ({
       onClick={handleClickFeed}
       isClickable={isClickable}
     >
-      <FlexBox alignItems="center">
+      <FlexBox alignItems="center" flexWrap="wrap">
         <ProfileImg src={picture} alt={`${nickname}님의 프로필 사진`} />
-        <FlexBox alignItems="center">
-          <Nickname size={20} color={themeContext.onBackground}>
-            {nickname}
-          </Nickname>
-          <OfText size={16} color={themeContext.onBackground}>
-            의&nbsp;
-          </OfText>
-          <ChallengeName
-            fontSize={20}
-            fontColor={themeContext.onBackground}
-            underLineColor={themeContext.primary}
-            fontWeight="bold"
-            onClick={handleClickChallengeName}
-          >
-            {challengeName.length > 9
-              ? `${challengeName.substring(0, 9)}...`
-              : challengeName}
-          </ChallengeName>
-        </FlexBox>
+        <Nickname size={20} color={themeContext.onBackground}>
+          {nickname}
+        </Nickname>
+        <OfText size={16} color={themeContext.onBackground}>
+          의&nbsp;
+        </OfText>
+        <ChallengeName
+          fontSize={20}
+          fontColor={themeContext.onBackground}
+          underLineColor={themeContext.primary}
+          fontWeight="bold"
+          onClick={handleClickChallengeName}
+        >
+          {isShowBriefChallengeName && challengeName.length > 9
+            ? `${challengeName.substring(0, 9)}...`
+            : challengeName}
+        </ChallengeName>
       </FlexBox>
       <ProgressImg
         src={progressImage}

--- a/frontend/src/components/FeedItem/index.tsx
+++ b/frontend/src/components/FeedItem/index.tsx
@@ -21,8 +21,22 @@ export const FeedItem = ({
 }: FeedItemProps) => {
   const themeContext = useThemeContext();
 
-  const { year, month, date, hours, minutes, handleClickFeed, handleClickChallengeName } =
-    useFeedItem({ challengeId, cycleDetailId, progressTime });
+  const {
+    year,
+    month,
+    date,
+    hours,
+    minutes,
+    renderedChallengeName,
+    handleClickFeed,
+    handleClickChallengeName,
+  } = useFeedItem({
+    challengeId,
+    cycleDetailId,
+    progressTime,
+    challengeName,
+    isShowBriefChallengeName,
+  });
 
   return (
     <Wrapper
@@ -46,9 +60,7 @@ export const FeedItem = ({
           fontWeight="bold"
           onClick={handleClickChallengeName}
         >
-          {isShowBriefChallengeName && challengeName.length > 9
-            ? `${challengeName.substring(0, 9)}...`
-            : challengeName}
+          {renderedChallengeName}
         </ChallengeName>
       </FlexBox>
       <ProgressImg

--- a/frontend/src/components/FeedItem/index.tsx
+++ b/frontend/src/components/FeedItem/index.tsx
@@ -39,7 +39,7 @@ export const FeedItem = ({
           <OfText size={16} color={themeContext.onBackground}>
             의&nbsp;
           </OfText>
-          <UnderLineText
+          <ChallengeName
             fontSize={20}
             fontColor={themeContext.onBackground}
             underLineColor={themeContext.primary}
@@ -49,7 +49,7 @@ export const FeedItem = ({
             {challengeName.length > 9
               ? `${challengeName.substring(0, 9)}...`
               : challengeName}
-          </UnderLineText>
+          </ChallengeName>
         </FlexBox>
       </FlexBox>
       <ProgressImg
@@ -91,6 +91,10 @@ const Nickname = styled(Text)`
 
 const OfText = styled(Text)`
   text-align: end;
+`;
+
+const ChallengeName = styled(UnderLineText)`
+  pointer-events: auto;
 `;
 
 const ProgressImg = styled.img`

--- a/frontend/src/components/FeedItem/index.tsx
+++ b/frontend/src/components/FeedItem/index.tsx
@@ -87,6 +87,10 @@ const Wrapper = styled(FlexBox)<WrapperProps>`
     padding: 20px 0;
     cursor: pointer;
     pointer-events: ${isClickable ? 'auto' : 'none'};
+
+    @media all and (max-width: 366px) {
+      min-width: auto;
+    }
   `}
 `;
 

--- a/frontend/src/components/FeedItem/type.ts
+++ b/frontend/src/components/FeedItem/type.ts
@@ -7,7 +7,11 @@ export interface FeedItemProps extends Feed {
 
 export type UseFeedProps = Pick<
   FeedItemProps,
-  'challengeId' | 'cycleDetailId' | 'progressTime'
+  | 'challengeId'
+  | 'cycleDetailId'
+  | 'progressTime'
+  | 'challengeName'
+  | 'isShowBriefChallengeName'
 >;
 
 export type WrapperProps = Pick<FeedItemProps, 'isClickable'>;

--- a/frontend/src/components/FeedItem/type.ts
+++ b/frontend/src/components/FeedItem/type.ts
@@ -2,6 +2,7 @@ import { Feed } from 'commonType';
 
 export interface FeedItemProps extends Feed {
   isClickable?: boolean;
+  isShowBriefChallengeName?: boolean;
 }
 
 export type UseFeedProps = Pick<

--- a/frontend/src/components/FeedItem/useFeedItem.ts
+++ b/frontend/src/components/FeedItem/useFeedItem.ts
@@ -5,9 +5,20 @@ import { parseTime } from 'utils';
 
 import { CLIENT_PATH } from 'constants/path';
 
-const useFeedItem = ({ challengeId, cycleDetailId, progressTime }: UseFeedProps) => {
+const useFeedItem = ({
+  challengeId,
+  cycleDetailId,
+  progressTime,
+  challengeName,
+  isShowBriefChallengeName,
+}: UseFeedProps) => {
   const navigate = useNavigate();
   const { year, month, date, hours, minutes } = parseTime(progressTime);
+
+  const renderedChallengeName =
+    isShowBriefChallengeName && challengeName.length > 9
+      ? `${challengeName.substring(0, 9)}...`
+      : challengeName;
 
   const handleClickFeed: MouseEventHandler<HTMLDivElement> = () => {
     navigate(`${CLIENT_PATH.FEED_DETAIL}/${cycleDetailId}`);
@@ -24,6 +35,7 @@ const useFeedItem = ({ challengeId, cycleDetailId, progressTime }: UseFeedProps)
     date,
     hours,
     minutes,
+    renderedChallengeName,
     handleClickFeed,
     handleClickChallengeName,
   };

--- a/frontend/src/mocks/data.ts
+++ b/frontend/src/mocks/data.ts
@@ -1,7 +1,7 @@
 export const challengeData = [
   {
     challengeId: 1,
-    challengeName: '미라클 모닝',
+    challengeName: '상쾌한 하루의 시작, 미라클 모닝!',
     challengerCount: 35,
     isInProgress: true,
     emojiIndex: 1,

--- a/frontend/src/pages/FeedDetailPage/index.tsx
+++ b/frontend/src/pages/FeedDetailPage/index.tsx
@@ -39,7 +39,7 @@ const FeedDetailPage = () => {
 
   return (
     <Wrapper flexDirection="column" alignItems="center">
-      <FeedItem isClickable={false} {...feedData.data} />
+      <FeedItem isClickable={false} isShowBriefChallengeName={false} {...feedData.data} />
       <CommentList as="ul" flexDirection="column" gap="1.563rem">
         {commentsData?.data.map((comment) => (
           <li key={comment.commentId}>

--- a/frontend/src/pages/FeedPage/index.tsx
+++ b/frontend/src/pages/FeedPage/index.tsx
@@ -73,4 +73,8 @@ const FeedContainer = styled.div`
   @media all and (max-width: 880px) {
     grid-template-columns: repeat(1, minmax(370px, max-content));
   }
+
+  @media all and (max-width: 366px) {
+    grid-template-columns: 100%;
+  }
 `;


### PR DESCRIPTION
close #380 

# 상세 페이지에서는 관련 챌린지로 이동이 안됨
## 해결 방안
FeedItem의 ChallengeName 스타일드 컴포넌트에 `pointer-events: auto` 스타일 추가했습니다. 이로인해 부모의 `pointer-events` 값에 관계없이 ChallengeName은 포인터 이벤트의 대상이 될 수 있습니다.

## 참고 자료
[MDN pointer-events](https://developer.mozilla.org/ko/docs/Web/CSS/pointer-events)

<br>

# 상세 페이지에서는 챌린지의 이름이 전체가 나와도 좋을 것 같음
## 에러 상황
### 피드 페이지
<img width="585" alt="피드 페이지 - 챌린지 이름 요약해서 보여줌" src="https://user-images.githubusercontent.com/52148907/188579852-e1c849d8-74a9-42cd-b721-69965a412271.png">

### 피드 상세 보기 페이지
<img width="585" alt="피드 상세 보기 페이지 - 피드 챌린지 이름  전체 보여줌" src="https://user-images.githubusercontent.com/52148907/188579861-cf4885ee-6b32-4da3-9560-c087a8010ac3.png">

`상쾌한 하루의 시작, 미라클 모닝!` 챌린지 이름을 피드 페이지에서는 요약해서 보이고, 피드 상세 페이지에서는 전체 이름을 보여주도록 구현했습니다.

## 해결 방안
FeedItem 컴포넌트에 isShowBriefChallengeName Props를 추가했습니다. isShowBriefChallengeName Props에 따라 챌린지 이름의 요약 여부를 결정하도록 구현했습니다.


