### PR TITLE
feat: (fe) 피드 페이지에서 progressCount 정보 추가

### DIFF
--- a/frontend/src/commonType.ts
+++ b/frontend/src/commonType.ts
@@ -59,9 +59,9 @@ export interface UserStat {
 
 export interface Feed
   extends Pick<User, 'picture' | 'nickname'>,
-    CycleDetail,
+    Pick<Cycle, 'progressCount'>,
+    CycleDetailWithId,
     Pick<Challenge, 'challengeId' | 'challengeName'> {
-  cycleDetailId: number;
   memberId: number;
   commentCount: number;
 }

--- a/frontend/src/components/FeedItem/index.tsx
+++ b/frontend/src/components/FeedItem/index.tsx
@@ -1,16 +1,18 @@
-import { FeedItemProps, WrapperProps } from './type';
+import { CheckSuccessCycleProps, FeedItemProps, WrapperProps } from './type';
 import useFeedItem from './useFeedItem';
+import { FaCrown } from 'react-icons/Fa';
 import styled, { css } from 'styled-components';
 
 import useThemeContext from 'hooks/useThemeContext';
 
-import { FlexBox, Text, UnderLineText } from 'components';
+import { FlexBox, Text, UnderLineText, CheckCircles } from 'components';
 
 export const FeedItem = ({
   cycleDetailId,
   picture,
   nickname,
   progressImage,
+  progressCount,
   description,
   progressTime,
   challengeId,
@@ -27,6 +29,7 @@ export const FeedItem = ({
     date,
     hours,
     minutes,
+    isSuccess,
     renderedChallengeName,
     handleClickFeed,
     handleClickChallengeName,
@@ -34,6 +37,7 @@ export const FeedItem = ({
     challengeId,
     cycleDetailId,
     progressTime,
+    progressCount,
     challengeName,
     isShowBriefChallengeName,
   });
@@ -44,6 +48,7 @@ export const FeedItem = ({
       gap="0.4rem"
       onClick={handleClickFeed}
       isClickable={isClickable}
+      isSuccess={isSuccess}
     >
       <FlexBox alignItems="center" flexWrap="wrap">
         <ProfileImg src={picture} alt={`${nickname}님의 프로필 사진`} loading="lazy" />
@@ -62,6 +67,10 @@ export const FeedItem = ({
         >
           {renderedChallengeName}
         </ChallengeName>
+        <CheckSuccessCycle isSuccess={isSuccess} />
+        <CheckCirclesWrapper justifyContent="flex-end">
+          <CheckCircles progressCount={progressCount} />
+        </CheckCirclesWrapper>
       </FlexBox>
       <ProgressImg
         src={progressImage}
@@ -81,13 +90,32 @@ export const FeedItem = ({
   );
 };
 
+const CheckSuccessCycle = ({ isSuccess }: CheckSuccessCycleProps) => {
+  const themeContext = useThemeContext();
+
+  if (!isSuccess) {
+    return null;
+  }
+
+  return (
+    <SuccessIconWrapper>
+      <FaCrown color={themeContext.primary} size={25} />
+    </SuccessIconWrapper>
+  );
+};
+
 const Wrapper = styled(FlexBox)<WrapperProps>`
-  ${({ isClickable }) => css`
+  ${({ theme, isClickable, isSuccess }) => css`
     max-width: 440px;
     min-width: 366px;
     padding: 20px 0;
     cursor: pointer;
     pointer-events: ${isClickable ? 'auto' : 'none'};
+    ${isSuccess &&
+    css`
+      border-radius: 20px;
+      border: 3px solid ${theme.primary};
+    `};
 
     @media all and (max-width: 366px) {
       min-width: auto;
@@ -131,4 +159,12 @@ const MainText = styled(Text)`
 
 const CommentCount = styled(Text)`
   align-self: flex-end;
+`;
+
+const CheckCirclesWrapper = styled(FlexBox)`
+  flex-grow: 1;
+`;
+
+const SuccessIconWrapper = styled.div`
+  margin-left: 5px;
 `;

--- a/frontend/src/components/FeedItem/index.tsx
+++ b/frontend/src/components/FeedItem/index.tsx
@@ -112,6 +112,7 @@ const Wrapper = styled(FlexBox)<WrapperProps>`
     cursor: pointer;
     pointer-events: ${isDetailPage ? 'none' : 'auto'};
     ${isSuccess &&
+    !isDetailPage &&
     css`
       border-radius: 20px;
       border: 3px solid ${theme.primary};

--- a/frontend/src/components/FeedItem/index.tsx
+++ b/frontend/src/components/FeedItem/index.tsx
@@ -1,4 +1,9 @@
-import { CheckSuccessCycleProps, FeedItemProps, WrapperProps } from './type';
+import {
+  CheckSuccessCycleProps,
+  FeedItemProps,
+  ProgressImgProps,
+  WrapperProps,
+} from './type';
 import useFeedItem from './useFeedItem';
 import { FaCrown } from 'react-icons/Fa';
 import styled, { css } from 'styled-components';
@@ -48,7 +53,6 @@ export const FeedItem = ({
       gap="0.4rem"
       onClick={handleClickFeed}
       isDetailPage={isDetailPage}
-      isSuccess={isSuccess}
     >
       <FlexBox alignItems="center" flexWrap="wrap">
         <ProfileImg src={picture} alt={`${nickname}님의 프로필 사진`} loading="lazy" />
@@ -76,6 +80,8 @@ export const FeedItem = ({
         src={progressImage}
         alt={`${nickname}님의 ${challengeName} 인증 사진`}
         loading="lazy"
+        isDetailPage={isDetailPage}
+        isSuccess={isSuccess}
       />
       <Text size={14} color={themeContext.mainText}>
         {`${year}.${month}.${date} ${hours}:${minutes}`}
@@ -105,18 +111,12 @@ const CheckSuccessCycle = ({ isSuccess }: CheckSuccessCycleProps) => {
 };
 
 const Wrapper = styled(FlexBox)<WrapperProps>`
-  ${({ theme, isDetailPage, isSuccess }) => css`
+  ${({ isDetailPage }) => css`
     max-width: 440px;
     min-width: 366px;
     padding: 20px 0;
     cursor: pointer;
     pointer-events: ${isDetailPage ? 'none' : 'auto'};
-    ${isSuccess &&
-    !isDetailPage &&
-    css`
-      border-radius: 20px;
-      border: 3px solid ${theme.primary};
-    `};
 
     @media all and (max-width: 366px) {
       min-width: auto;
@@ -142,13 +142,24 @@ const ChallengeName = styled(UnderLineText)`
   pointer-events: auto;
 `;
 
-const ProgressImg = styled.img`
-  width: 100%;
-  height: 400px;
-  object-fit: cover;
-  border-radius: 20px;
-  background-color: white;
-  margin: 0.5rem 0;
+const ProgressImg = styled.img<ProgressImgProps>`
+  ${({ theme, isDetailPage, isSuccess }) => css`
+    width: 100%;
+    height: 400px;
+    object-fit: cover;
+    border-radius: 20px;
+    background-color: white;
+    margin: 0.2rem 0.1rem;
+    ${isSuccess &&
+    !isDetailPage &&
+    css`
+      border: 8px solid transparent;
+      background-image: linear-gradient(#fff, #fff),
+        linear-gradient(to bottom right, ${theme.primary}, #ffd700);
+      background-origin: border-box;
+      background-clip: content-box, border-box;
+    `};
+  `}
 `;
 
 const MainText = styled(Text)`

--- a/frontend/src/components/FeedItem/index.tsx
+++ b/frontend/src/components/FeedItem/index.tsx
@@ -1,9 +1,4 @@
-import {
-  CheckSuccessCycleProps,
-  FeedItemProps,
-  ProgressImgProps,
-  WrapperProps,
-} from './type';
+import { CheckSuccessProps, FeedItemProps, WrapperProps } from './type';
 import useFeedItem from './useFeedItem';
 import { FaCrown } from 'react-icons/Fa';
 import styled, { css } from 'styled-components';
@@ -72,15 +67,14 @@ export const FeedItem = ({
           {renderedChallengeName}
         </ChallengeName>
         <CheckSuccessCycle isSuccess={isSuccess} />
-        <CheckCirclesWrapper justifyContent="flex-end">
-          <CheckCircles progressCount={progressCount} />
-        </CheckCirclesWrapper>
       </FlexBox>
+      <CheckCirclesWrapper justifyContent="flex-end">
+        <CheckCircles progressCount={progressCount} />
+      </CheckCirclesWrapper>
       <ProgressImg
         src={progressImage}
         alt={`${nickname}님의 ${challengeName} 인증 사진`}
         loading="lazy"
-        isDetailPage={isDetailPage}
         isSuccess={isSuccess}
       />
       <Text size={14} color={themeContext.mainText}>
@@ -96,7 +90,7 @@ export const FeedItem = ({
   );
 };
 
-const CheckSuccessCycle = ({ isSuccess }: CheckSuccessCycleProps) => {
+const CheckSuccessCycle = ({ isSuccess }: CheckSuccessProps) => {
   const themeContext = useThemeContext();
 
   if (!isSuccess) {
@@ -142,8 +136,8 @@ const ChallengeName = styled(UnderLineText)`
   pointer-events: auto;
 `;
 
-const ProgressImg = styled.img<ProgressImgProps>`
-  ${({ theme, isDetailPage, isSuccess }) => css`
+const ProgressImg = styled.img<CheckSuccessProps>`
+  ${({ theme, isSuccess }) => css`
     width: 100%;
     height: 400px;
     object-fit: cover;
@@ -151,7 +145,6 @@ const ProgressImg = styled.img<ProgressImgProps>`
     background-color: white;
     margin: 0.2rem 0.1rem;
     ${isSuccess &&
-    !isDetailPage &&
     css`
       border: 8px solid transparent;
       background-image: linear-gradient(#fff, #fff),

--- a/frontend/src/components/FeedItem/index.tsx
+++ b/frontend/src/components/FeedItem/index.tsx
@@ -18,7 +18,7 @@ export const FeedItem = ({
   challengeId,
   challengeName,
   commentCount,
-  isClickable = true,
+  isDetailPage = false,
   isShowBriefChallengeName = true,
 }: FeedItemProps) => {
   const themeContext = useThemeContext();
@@ -47,7 +47,7 @@ export const FeedItem = ({
       flexDirection="column"
       gap="0.4rem"
       onClick={handleClickFeed}
-      isClickable={isClickable}
+      isDetailPage={isDetailPage}
       isSuccess={isSuccess}
     >
       <FlexBox alignItems="center" flexWrap="wrap">
@@ -105,12 +105,12 @@ const CheckSuccessCycle = ({ isSuccess }: CheckSuccessCycleProps) => {
 };
 
 const Wrapper = styled(FlexBox)<WrapperProps>`
-  ${({ theme, isClickable, isSuccess }) => css`
+  ${({ theme, isDetailPage, isSuccess }) => css`
     max-width: 440px;
     min-width: 366px;
     padding: 20px 0;
     cursor: pointer;
-    pointer-events: ${isClickable ? 'auto' : 'none'};
+    pointer-events: ${isDetailPage ? 'none' : 'auto'};
     ${isSuccess &&
     css`
       border-radius: 20px;

--- a/frontend/src/components/FeedItem/type.ts
+++ b/frontend/src/components/FeedItem/type.ts
@@ -15,8 +15,10 @@ export type UseFeedProps = Pick<
   | 'isShowBriefChallengeName'
 >;
 
-export interface WrapperProps extends Pick<FeedItemProps, 'isDetailPage'> {
+export type WrapperProps = Pick<FeedItemProps, 'isDetailPage'>;
+
+export interface ProgressImgProps extends Pick<FeedItemProps, 'isDetailPage'> {
   isSuccess: boolean;
 }
 
-export type CheckSuccessCycleProps = Pick<WrapperProps, 'isSuccess'>;
+export type CheckSuccessCycleProps = Pick<ProgressImgProps, 'isSuccess'>;

--- a/frontend/src/components/FeedItem/type.ts
+++ b/frontend/src/components/FeedItem/type.ts
@@ -17,8 +17,6 @@ export type UseFeedProps = Pick<
 
 export type WrapperProps = Pick<FeedItemProps, 'isDetailPage'>;
 
-export interface ProgressImgProps extends Pick<FeedItemProps, 'isDetailPage'> {
+export interface CheckSuccessProps {
   isSuccess: boolean;
 }
-
-export type CheckSuccessCycleProps = Pick<ProgressImgProps, 'isSuccess'>;

--- a/frontend/src/components/FeedItem/type.ts
+++ b/frontend/src/components/FeedItem/type.ts
@@ -10,8 +10,13 @@ export type UseFeedProps = Pick<
   | 'challengeId'
   | 'cycleDetailId'
   | 'progressTime'
+  | 'progressCount'
   | 'challengeName'
   | 'isShowBriefChallengeName'
 >;
 
-export type WrapperProps = Pick<FeedItemProps, 'isClickable'>;
+export interface WrapperProps extends Pick<FeedItemProps, 'isClickable'> {
+  isSuccess: boolean;
+}
+
+export type CheckSuccessCycleProps = Pick<WrapperProps, 'isSuccess'>;

--- a/frontend/src/components/FeedItem/type.ts
+++ b/frontend/src/components/FeedItem/type.ts
@@ -1,7 +1,7 @@
 import { Feed } from 'commonType';
 
 export interface FeedItemProps extends Feed {
-  isClickable?: boolean;
+  isDetailPage?: boolean;
   isShowBriefChallengeName?: boolean;
 }
 
@@ -15,7 +15,7 @@ export type UseFeedProps = Pick<
   | 'isShowBriefChallengeName'
 >;
 
-export interface WrapperProps extends Pick<FeedItemProps, 'isClickable'> {
+export interface WrapperProps extends Pick<FeedItemProps, 'isDetailPage'> {
   isSuccess: boolean;
 }
 

--- a/frontend/src/components/FeedItem/useFeedItem.ts
+++ b/frontend/src/components/FeedItem/useFeedItem.ts
@@ -3,17 +3,20 @@ import { MouseEventHandler } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { parseTime } from 'utils';
 
+import { CYCLE_SUCCESS_CRITERIA } from 'constants/domain';
 import { CLIENT_PATH } from 'constants/path';
 
 const useFeedItem = ({
   challengeId,
   cycleDetailId,
   progressTime,
+  progressCount,
   challengeName,
   isShowBriefChallengeName,
 }: UseFeedProps) => {
   const navigate = useNavigate();
   const { year, month, date, hours, minutes } = parseTime(progressTime);
+  const isSuccess = progressCount == CYCLE_SUCCESS_CRITERIA;
 
   const renderedChallengeName =
     isShowBriefChallengeName && challengeName.length > 9
@@ -35,6 +38,7 @@ const useFeedItem = ({
     date,
     hours,
     minutes,
+    isSuccess,
     renderedChallengeName,
     handleClickFeed,
     handleClickChallengeName,

--- a/frontend/src/mocks/data.ts
+++ b/frontend/src/mocks/data.ts
@@ -650,7 +650,8 @@ export const cycleDetailData = {
       progressImage:
         'https://health.chosun.com/site/data/img_dir/2018/03/07/2018030700812_2.jpg',
       progressTime: '2022-07-01T17:00:00',
-      description: '알찼다.',
+      description:
+        'absdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvawabsdvaw',
     },
     {
       progressImage:
@@ -825,6 +826,7 @@ export const feedData = [
       'https://cdn.pixabay.com/photo/2022/08/03/04/41/beech-leaves-7361863_1280.jpg',
     nickname: '유저1',
     progressImage: 'https://i.ibb.co/mJwjFq1/progress-Image.png',
+    progressCount: 1,
     description:
       '바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^',
     progressTime: '2022-08-08T10:00:00',
@@ -839,6 +841,7 @@ export const feedData = [
     nickname: userData.nickname,
     progressImage:
       'https://cdn.pixabay.com/photo/2019/07/21/13/42/nature-conservation-4352793_1280.jpg',
+    progressCount: 2,
     description:
       'Moo https://www.acmicpc.net/problem/5904 https://github.com/tonic523/Algorithm/tree/main/%EB%B6%84%ED%95%A0%20%EC%A0%95%EB%B3%B5/Moo%20%EA%B2%8C%EC%9E%84',
     progressTime: '2022-08-08T10:00:00',
@@ -853,6 +856,7 @@ export const feedData = [
       'https://cdn.pixabay.com/photo/2022/08/03/04/41/beech-leaves-7361863_1280.jpg',
     nickname: '유저1',
     progressImage: 'https://cdn.pixabay.com/photo/2016/11/18/16/56/book-1835799_1280.jpg',
+    progressCount: 3,
     description: '오늘도 독서 완료!',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[2].challengeId,
@@ -867,6 +871,7 @@ export const feedData = [
     nickname: '유저1',
     progressImage:
       'https://cdn.pixabay.com/photo/2015/07/13/16/49/night-table-lamp-843461_1280.jpg',
+    progressCount: 2,
     description: '오늘 일찍 잠~~',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[3].challengeId,
@@ -880,6 +885,7 @@ export const feedData = [
       'https://cdn.pixabay.com/photo/2022/08/03/04/41/beech-leaves-7361863_1280.jpg',
     nickname: '유저1',
     progressImage: 'https://cdn.pixabay.com/photo/2015/07/28/22/05/child-865116_1280.jpg',
+    progressCount: 2,
     description: '오늘도 열심히 공부했어요~~!',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[1].challengeId,
@@ -893,6 +899,7 @@ export const feedData = [
       'https://cdn.pixabay.com/photo/2022/08/03/04/41/beech-leaves-7361863_1280.jpg',
     nickname: '유저1',
     progressImage: 'https://cdn.pixabay.com/photo/2015/03/09/18/34/beach-666122_1280.jpg',
+    progressCount: 2,
     description: '바다가 너무 예쁘네요^_^',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[0].challengeId,
@@ -906,6 +913,7 @@ export const feedData = [
     nickname: userData.nickname,
     progressImage:
       'https://cdn.pixabay.com/photo/2019/07/21/13/42/nature-conservation-4352793_1280.jpg',
+    progressCount: 2,
     description: '오늘 날씨가 너무 좋아요~!',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[0].challengeId,
@@ -919,6 +927,7 @@ export const feedData = [
       'https://cdn.pixabay.com/photo/2022/08/03/04/41/beech-leaves-7361863_1280.jpg',
     nickname: '유저1',
     progressImage: 'https://cdn.pixabay.com/photo/2016/11/18/16/56/book-1835799_1280.jpg',
+    progressCount: 2,
     description: '오늘도 독서 완료!',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[2].challengeId,
@@ -933,6 +942,7 @@ export const feedData = [
     nickname: '유저1',
     progressImage:
       'https://cdn.pixabay.com/photo/2015/07/13/16/49/night-table-lamp-843461_1280.jpg',
+    progressCount: 2,
     description: '오늘 일찍 잠~~',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[3].challengeId,
@@ -946,6 +956,7 @@ export const feedData = [
       'https://cdn.pixabay.com/photo/2022/08/03/04/41/beech-leaves-7361863_1280.jpg',
     nickname: '유저1',
     progressImage: 'https://cdn.pixabay.com/photo/2015/07/28/22/05/child-865116_1280.jpg',
+    progressCount: 2,
     description: '오늘도 열심히 공부했어요~~!',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[1].challengeId,
@@ -959,6 +970,7 @@ export const feedData = [
       'https://cdn.pixabay.com/photo/2022/08/03/04/41/beech-leaves-7361863_1280.jpg',
     nickname: '유저1',
     progressImage: 'https://cdn.pixabay.com/photo/2015/03/09/18/34/beach-666122_1280.jpg',
+    progressCount: 2,
     description: '바다가 너무 예쁘네요^_^',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[0].challengeId,
@@ -972,6 +984,7 @@ export const feedData = [
     nickname: userData.nickname,
     progressImage:
       'https://cdn.pixabay.com/photo/2019/07/21/13/42/nature-conservation-4352793_1280.jpg',
+    progressCount: 2,
     description: '오늘 날씨가 너무 좋아요~!',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[0].challengeId,
@@ -985,6 +998,7 @@ export const feedData = [
       'https://cdn.pixabay.com/photo/2022/08/03/04/41/beech-leaves-7361863_1280.jpg',
     nickname: '유저1',
     progressImage: 'https://cdn.pixabay.com/photo/2016/11/18/16/56/book-1835799_1280.jpg',
+    progressCount: 2,
     description: '오늘도 독서 완료!',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[2].challengeId,
@@ -999,6 +1013,7 @@ export const feedData = [
     nickname: '유저1',
     progressImage:
       'https://cdn.pixabay.com/photo/2015/07/13/16/49/night-table-lamp-843461_1280.jpg',
+    progressCount: 2,
     description: '오늘 일찍 잠~~',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[3].challengeId,
@@ -1012,6 +1027,7 @@ export const feedData = [
       'https://cdn.pixabay.com/photo/2022/08/03/04/41/beech-leaves-7361863_1280.jpg',
     nickname: '유저1',
     progressImage: 'https://cdn.pixabay.com/photo/2015/07/28/22/05/child-865116_1280.jpg',
+    progressCount: 2,
     description: '오늘도 열심히 공부했어요~~!',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[1].challengeId,
@@ -1025,6 +1041,7 @@ export const feedData = [
       'https://cdn.pixabay.com/photo/2022/08/03/04/41/beech-leaves-7361863_1280.jpg',
     nickname: '유저1',
     progressImage: 'https://cdn.pixabay.com/photo/2015/03/09/18/34/beach-666122_1280.jpg',
+    progressCount: 2,
     description: '바다가 너무 예쁘네요^_^',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[0].challengeId,
@@ -1038,6 +1055,7 @@ export const feedData = [
     nickname: userData.nickname,
     progressImage:
       'https://cdn.pixabay.com/photo/2019/07/21/13/42/nature-conservation-4352793_1280.jpg',
+    progressCount: 2,
     description: '오늘 날씨가 너무 좋아요~!',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[0].challengeId,
@@ -1051,6 +1069,7 @@ export const feedData = [
       'https://cdn.pixabay.com/photo/2022/08/03/04/41/beech-leaves-7361863_1280.jpg',
     nickname: '유저1',
     progressImage: 'https://cdn.pixabay.com/photo/2016/11/18/16/56/book-1835799_1280.jpg',
+    progressCount: 2,
     description: '오늘도 독서 완료!',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[2].challengeId,
@@ -1065,6 +1084,7 @@ export const feedData = [
     nickname: '유저1',
     progressImage:
       'https://cdn.pixabay.com/photo/2015/07/13/16/49/night-table-lamp-843461_1280.jpg',
+    progressCount: 2,
     description: '오늘 일찍 잠~~',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[3].challengeId,
@@ -1078,6 +1098,7 @@ export const feedData = [
       'https://cdn.pixabay.com/photo/2022/08/03/04/41/beech-leaves-7361863_1280.jpg',
     nickname: '유저1',
     progressImage: 'https://cdn.pixabay.com/photo/2015/07/28/22/05/child-865116_1280.jpg',
+    progressCount: 2,
     description: '오늘도 열심히 공부했어요~~!',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[1].challengeId,
@@ -1091,6 +1112,7 @@ export const feedData = [
       'https://cdn.pixabay.com/photo/2022/08/03/04/41/beech-leaves-7361863_1280.jpg',
     nickname: '유저1',
     progressImage: 'https://cdn.pixabay.com/photo/2015/03/09/18/34/beach-666122_1280.jpg',
+    progressCount: 2,
     description: '바다가 너무 예쁘네요^_^',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[0].challengeId,
@@ -1104,6 +1126,7 @@ export const feedData = [
     nickname: userData.nickname,
     progressImage:
       'https://cdn.pixabay.com/photo/2019/07/21/13/42/nature-conservation-4352793_1280.jpg',
+    progressCount: 2,
     description: '오늘 날씨가 너무 좋아요~!',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[0].challengeId,
@@ -1117,6 +1140,7 @@ export const feedData = [
       'https://cdn.pixabay.com/photo/2022/08/03/04/41/beech-leaves-7361863_1280.jpg',
     nickname: '유저1',
     progressImage: 'https://cdn.pixabay.com/photo/2016/11/18/16/56/book-1835799_1280.jpg',
+    progressCount: 2,
     description: '오늘도 독서 완료!',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[2].challengeId,
@@ -1131,6 +1155,7 @@ export const feedData = [
     nickname: '유저1',
     progressImage:
       'https://cdn.pixabay.com/photo/2015/07/13/16/49/night-table-lamp-843461_1280.jpg',
+    progressCount: 2,
     description: '오늘 일찍 잠~~',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[3].challengeId,
@@ -1144,6 +1169,7 @@ export const feedData = [
       'https://cdn.pixabay.com/photo/2022/08/03/04/41/beech-leaves-7361863_1280.jpg',
     nickname: '유저1',
     progressImage: 'https://cdn.pixabay.com/photo/2015/07/28/22/05/child-865116_1280.jpg',
+    progressCount: 2,
     description: '오늘도 열심히 공부했어요~~!',
     progressTime: '2022-08-08T10:00:00',
     challengeId: challengeData[1].challengeId,

--- a/frontend/src/pages/FeedDetailPage/index.tsx
+++ b/frontend/src/pages/FeedDetailPage/index.tsx
@@ -39,7 +39,7 @@ const FeedDetailPage = () => {
 
   return (
     <Wrapper flexDirection="column" alignItems="center">
-      <FeedItem isClickable={false} isShowBriefChallengeName={false} {...feedData.data} />
+      <FeedItem isDetailPage={true} isShowBriefChallengeName={false} {...feedData.data} />
       <CommentList as="ul" flexDirection="column" gap="1.563rem">
         {commentsData?.data.map((comment) => (
           <li key={comment.commentId}>


### PR DESCRIPTION
- [x] API 수정
- [x] 피드 UI 수정
- [x] 피드 디테일 페이지 UI 수정

### 변경한 UI
![image](https://user-images.githubusercontent.com/70249108/190968901-c8543a37-99d6-4d19-9ba8-937868a6a98e.png)
![image](https://user-images.githubusercontent.com/70249108/190968936-4ac776ae-cced-49bc-8a4a-9ca3bec84f6d.png)

- CheckCircles 추가
- 성공한 cycle일 때
  - 왕관 추가
  - 테두리 추가
