### PR TITLE
feat: (be) 쿼리 튜닝

### DIFF
--- a/backend/smody/src/main/java/com/woowacourse/smody/challenge/domain/ChallengingRecord.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/challenge/domain/ChallengingRecord.java
@@ -8,17 +8,27 @@ import com.woowacourse.smody.exception.BusinessException;
 import com.woowacourse.smody.exception.ExceptionData;
 import com.woowacourse.smody.member.domain.Member;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
 public class ChallengingRecord {
 
-    private final List<Cycle> cycles;
+    private final List<Cycle> cycles; // 최근 Cycle(member, challenge, 인증 시간), 성공 회수
+    private final Long successCount;
 
     ChallengingRecord(List<Cycle> cycles) {
         validateOnlyMember(cycles);
         validateOnlyChallenge(cycles);
         this.cycles = cycles;
+        this.successCount = cycles.stream()
+                .filter(Cycle::isSuccess)
+                .count();
+    }
+
+    public ChallengingRecord(Cycle cycle, Long successCount) {
+        this.cycles = List.of(cycle);
+        this.successCount = successCount;
     }
 
     public static List<ChallengingRecord> from(List<Cycle> cycles) {
@@ -50,9 +60,7 @@ public class ChallengingRecord {
     }
 
     public int getSuccessCount() {
-        return (int) cycles.stream()
-                .filter(Cycle::isSuccess)
-                .count();
+        return successCount.intValue();
     }
 
     public LocalDateTime getLatestProgressTime() {
@@ -71,5 +79,25 @@ public class ChallengingRecord {
         return cycles.get(0)
                 .getMember()
                 .equals(member);
+    }
+
+    public boolean match(Cycle cycle) {
+        return cycles.get(0)
+                .equals(cycle);
+    }
+
+    public boolean isInProgress(LocalDateTime searchTime) {
+        return cycles.get(0)
+                .isInProgress(searchTime);
+    }
+
+    public long getEndTime(LocalDateTime searchTime) {
+        // 진행중인 사이클이 있는지
+        return cycles.get(0)
+                .calculateEndTime(searchTime);
+    }
+
+    public Cycle getCycle() {
+        return cycles.get(0);
     }
 }

--- a/backend/smody/src/main/java/com/woowacourse/smody/challenge/domain/ChallengingRecord.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/challenge/domain/ChallengingRecord.java
@@ -8,7 +8,6 @@ import com.woowacourse.smody.exception.BusinessException;
 import com.woowacourse.smody.exception.ExceptionData;
 import com.woowacourse.smody.member.domain.Member;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 

--- a/backend/smody/src/main/java/com/woowacourse/smody/challenge/service/ChallengeQueryService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/challenge/service/ChallengeQueryService.java
@@ -39,9 +39,9 @@ public class ChallengeQueryService {
     public List<ChallengeTabResponse> findAllWithChallengerCount(TokenPayload tokenPayload, LocalDateTime searchTime,
                                                                  PagingParams pagingParams) {
         Member member = memberService.findMember(tokenPayload);
-        List<Cycle> cycles = cycleService.searchInProgress(searchTime);
-        ChallengingRecords challengingRecords = ChallengingRecords.from(cycles);
         List<Challenge> challenges = challengeService.searchAll(pagingParams);
+        List<Cycle> cycles = cycleService.searchInProgressByChallenges(searchTime, challenges);
+        ChallengingRecords challengingRecords = ChallengingRecords.from(cycles);
         return getChallengeTabResponses(challenges, member, challengingRecords);
     }
 

--- a/backend/smody/src/main/java/com/woowacourse/smody/challenge/service/ChallengeQueryService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/challenge/service/ChallengeQueryService.java
@@ -63,9 +63,9 @@ public class ChallengeQueryService {
     public ChallengeResponse findWithChallengerCount(TokenPayload tokenPayload, LocalDateTime searchTime,
                                                      Long challengeId) {
         Member member = memberService.findMember(tokenPayload);
-        List<Cycle> cycles = cycleService.searchInProgress(searchTime);
-        ChallengingRecords challengingRecords = ChallengingRecords.from(cycles);
         Challenge challenge = challengeService.search(challengeId);
+        List<Cycle> cycles = cycleService.searchInProgressByChallenge(searchTime, challenge);
+        ChallengingRecords challengingRecords = ChallengingRecords.from(cycles);
         return new ChallengeResponse(
                 challenge,
                 challengingRecords.countChallenger(challenge),
@@ -108,11 +108,8 @@ public class ChallengeQueryService {
 
     public List<ChallengersResponse> findAllChallengers(Long challengeId) {
         Challenge challenge = challengeService.search(challengeId);
-        List<Cycle> inProgressCycle = cycleService.searchInProgress(LocalDateTime.now())
-                .stream()
-                .filter(cycle -> cycle.matchChallenge(challenge.getId()))
-                .collect(toList());
-        return inProgressCycle.stream()
+        List<Cycle> cycles = cycleService.searchInProgressByChallenge(LocalDateTime.now(), challenge);
+        return cycles.stream()
                 .map(cycle -> new ChallengersResponse(
                         cycle.getMember(), cycle.getProgress().getCount()))
                 .collect(toList());

--- a/backend/smody/src/main/java/com/woowacourse/smody/comment/service/CommentQueryService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/comment/service/CommentQueryService.java
@@ -4,8 +4,6 @@ import com.woowacourse.smody.auth.dto.TokenPayload;
 import com.woowacourse.smody.comment.domain.Comment;
 import com.woowacourse.smody.comment.dto.CommentResponse;
 import com.woowacourse.smody.comment.repository.CommentRepository;
-import com.woowacourse.smody.feed.domain.Feed;
-import com.woowacourse.smody.feed.service.FeedService;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -16,11 +14,9 @@ import org.springframework.stereotype.Service;
 public class CommentQueryService {
 
     private final CommentRepository commentRepository;
-    private final FeedService feedService;
 
     public List<CommentResponse> findAllByCycleDetailId(TokenPayload tokenPayload, Long cycleDetailId) {
-        Feed feed = feedService.search(cycleDetailId);
-        List<Comment> comments = commentRepository.findAllByCycleDetailId(feed.getCycleDetailId());
+        List<Comment> comments = commentRepository.findAllByCycleDetailId(cycleDetailId);
         return comments.stream()
                 .map(comment -> new CommentResponse(comment, comment.isCommentByMemberId(tokenPayload.getId())))
                 .collect(Collectors.toList());

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/Cycle.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/Cycle.java
@@ -108,10 +108,6 @@ public class Cycle {
                 .collect(Collectors.toList());
     }
 
-    public boolean matchChallenge(Long challengeId) {
-        return this.challenge.getId().equals(challengeId);
-    }
-
     public int getInterval() {
         return progress.getCount() + 1;
     }

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/Cycle.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/Cycle.java
@@ -25,6 +25,7 @@ import javax.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -47,6 +48,7 @@ public class Cycle {
     private Challenge challenge;
 
     @OneToMany(mappedBy = "cycle", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    @BatchSize(size = 10)
     private List<CycleDetail> cycleDetails = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/repository/CycleRepository.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/repository/CycleRepository.java
@@ -10,8 +10,10 @@ import javax.persistence.LockModeType;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface CycleRepository extends JpaRepository<Cycle, Long>, DynamicCycleRepository {
 
@@ -25,10 +27,6 @@ public interface CycleRepository extends JpaRepository<Cycle, Long>, DynamicCycl
     List<Cycle> findAllByStartTimeIsAfterAndChallenge(@Param("time") LocalDateTime time,
                                                       @Param("challenge") Challenge challenge);
 
-    @EntityGraph(attributePaths = "challenge")
-    @Query("select c from Cycle c where c.member = :member and c.startTime >= :time")
-    List<Cycle> findByMemberAfterTime(@Param("member") Member member, @Param("time") LocalDateTime time);
-
     @Query("select count(c) from Cycle c where c.member = :member and "
             + "c.challenge = :challenge and c.progress = 'SUCCESS'")
     Long countSuccess(@Param("member") Member member, @Param("challenge") Challenge challenge);
@@ -40,7 +38,9 @@ public interface CycleRepository extends JpaRepository<Cycle, Long>, DynamicCycl
 
     List<Cycle> findByMember(Member member);
 
-    void deleteByMember(Member member);
+    @Modifying
+    @Query("delete from Cycle c where c.member = :member")
+    void deleteByMember(@Param("member") Member member);
 
     @Lock(LockModeType.PESSIMISTIC_READ)
     @Query("select c from Cycle c where c.id = :id")

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/repository/CycleRepository.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/repository/CycleRepository.java
@@ -17,6 +17,10 @@ public interface CycleRepository extends JpaRepository<Cycle, Long>, DynamicCycl
 
     List<Cycle> findAllByStartTimeIsAfter(LocalDateTime time);
 
+    @Query("select c from Cycle c where c.startTime >= :time and c.challenge in :challenges")
+    List<Cycle> findAllByStartTimeIsAfterAndChallengeIn(@Param("time") LocalDateTime time,
+                                                        @Param("challenges") List<Challenge> challenges);
+
     @EntityGraph(attributePaths = "challenge")
     @Query("select c from Cycle c where c.member = :member and c.startTime >= :time")
     List<Cycle> findByMemberAfterTime(@Param("member") Member member, @Param("time") LocalDateTime time);
@@ -31,11 +35,6 @@ public interface CycleRepository extends JpaRepository<Cycle, Long>, DynamicCycl
     Optional<Cycle> findRecent(@Param("memberId") Member member, @Param("challengeId") Challenge challenge);
 
     List<Cycle> findByMember(Member member);
-
-    @EntityGraph(attributePaths = "challenge")
-    @Query("select c from Cycle c where c.member = :member and c.progress = 'SUCCESS' " +
-            "order by c.startTime DESC")
-    List<Cycle> findAllSuccessLatest(@Param("member") Member member);
 
     void deleteByMember(Member member);
 

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/repository/CycleRepository.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/repository/CycleRepository.java
@@ -21,6 +21,10 @@ public interface CycleRepository extends JpaRepository<Cycle, Long>, DynamicCycl
     List<Cycle> findAllByStartTimeIsAfterAndChallengeIn(@Param("time") LocalDateTime time,
                                                         @Param("challenges") List<Challenge> challenges);
 
+    @Query("select c from Cycle c where c.startTime >= :time and c.challenge = :challenge")
+    List<Cycle> findAllByStartTimeIsAfterAndChallenge(@Param("time") LocalDateTime time,
+                                                      @Param("challenge") Challenge challenge);
+
     @EntityGraph(attributePaths = "challenge")
     @Query("select c from Cycle c where c.member = :member and c.startTime >= :time")
     List<Cycle> findByMemberAfterTime(@Param("member") Member member, @Param("time") LocalDateTime time);

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/repository/DynamicCycleRepository.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/repository/DynamicCycleRepository.java
@@ -1,7 +1,9 @@
 package com.woowacourse.smody.cycle.repository;
 
+import com.woowacourse.smody.challenge.domain.ChallengingRecord;
 import com.woowacourse.smody.cycle.domain.Cycle;
 import com.woowacourse.smody.db_support.PagingParams;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface DynamicCycleRepository {
@@ -10,4 +12,5 @@ public interface DynamicCycleRepository {
 
     List<Cycle> findAllByMember(Long memberId, PagingParams pagingParams);
 
+    List<ChallengingRecord> findAllChallengingRecordByMemberAfterTime(Long memberId, LocalDateTime time);
 }

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/service/CycleService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/service/CycleService.java
@@ -133,4 +133,11 @@ public class CycleService {
                 .filter(cycle -> cycle.isInProgress(searchTime))
                 .collect(toList());
     }
+
+    public List<Cycle> searchInProgressByChallenge(LocalDateTime searchTime, Challenge challenge) {
+        return cycleRepository.findAllByStartTimeIsAfterAndChallenge(searchTime.minusDays(Cycle.DAYS), challenge)
+                .stream()
+                .filter(cycle -> cycle.isInProgress(searchTime))
+                .collect(toList());
+    }
 }

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/service/CycleService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/service/CycleService.java
@@ -97,20 +97,6 @@ public class CycleService {
                 .orElseThrow(() -> new BusinessException(ExceptionData.NOT_FOUND_CYCLE));
     }
 
-    public List<Cycle> searchInProgressByMember(LocalDateTime searchTime, Member member) {
-        return cycleRepository.findByMemberAfterTime(member, searchTime.minusDays(Cycle.DAYS))
-                .stream()
-                .filter(cycle -> cycle.isInProgress(searchTime))
-                .collect(toList());
-    }
-
-    public List<Cycle> searchInProgress(LocalDateTime searchTime) {
-        return cycleRepository.findAllByStartTimeIsAfter(searchTime.minusDays(Cycle.DAYS))
-                .stream()
-                .filter(cycle -> cycle.isInProgress(searchTime))
-                .collect(toList());
-    }
-
     public Optional<Cycle> findById(Long id) {
         return cycleRepository.findById(id);
     }

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/service/CycleService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/service/CycleService.java
@@ -126,4 +126,11 @@ public class CycleService {
     public List<Cycle> findAllByMember(Member member, PagingParams pagingParams) {
         return cycleRepository.findAllByMember(member.getId(), pagingParams);
     }
+
+    public List<Cycle> searchInProgressByChallenges(LocalDateTime searchTime, List<Challenge> challenges) {
+        return cycleRepository.findAllByStartTimeIsAfterAndChallengeIn(searchTime.minusDays(Cycle.DAYS), challenges)
+                .stream()
+                .filter(cycle -> cycle.isInProgress(searchTime))
+                .collect(toList());
+    }
 }

--- a/backend/smody/src/main/java/com/woowacourse/smody/feed/domain/Feed.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/feed/domain/Feed.java
@@ -1,9 +1,7 @@
 package com.woowacourse.smody.feed.domain;
 
-import java.time.LocalDateTime;
-
 import com.woowacourse.smody.cycle.domain.Progress;
-
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/backend/smody/src/main/java/com/woowacourse/smody/feed/dto/FeedResponse.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/feed/dto/FeedResponse.java
@@ -1,9 +1,7 @@
 package com.woowacourse.smody.feed.dto;
 
-import java.time.LocalDateTime;
-
 import com.woowacourse.smody.feed.domain.Feed;
-
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/backend/smody/src/main/java/com/woowacourse/smody/feed/repository/FeedDynamicRepositoryImpl.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/feed/repository/FeedDynamicRepositoryImpl.java
@@ -1,7 +1,10 @@
 package com.woowacourse.smody.feed.repository;
 
+import static com.woowacourse.smody.challenge.domain.QChallenge.challenge;
 import static com.woowacourse.smody.comment.domain.QComment.comment;
+import static com.woowacourse.smody.cycle.domain.QCycle.cycle;
 import static com.woowacourse.smody.cycle.domain.QCycleDetail.cycleDetail;
+import static com.woowacourse.smody.member.domain.QMember.member;
 
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.ExpressionUtils;
@@ -30,8 +33,8 @@ public class FeedDynamicRepositoryImpl implements FeedDynamicRepository {
     private static final Expression<?>[] FEED_FIELDS = {
             cycleDetail.id, cycleDetail.progressImage, cycleDetail.description,
             cycleDetail.progressTime, cycleDetail.progress,
-            cycleDetail.cycle.member.id, cycleDetail.cycle.member.picture, cycleDetail.cycle.member.nickname,
-            cycleDetail.cycle.challenge.id, cycleDetail.cycle.challenge.name,
+            member.id, member.picture, member.nickname,
+            challenge.id, challenge.name,
             COMMENT_COUNT
     };
 
@@ -48,6 +51,9 @@ public class FeedDynamicRepositoryImpl implements FeedDynamicRepository {
         return queryFactory
                 .select(Projections.constructor(Feed.class, FEED_FIELDS))
                 .from(cycleDetail)
+                .join(cycleDetail.cycle, cycle)
+                .join(cycle.member, member)
+                .join(cycle.challenge, challenge)
                 .where(DynamicQuery.builder()
                         .and(() -> cycleDetail.id.ne(cycleDetailId))
                         .and(() -> cycleDetail.progressTime.loe(progressTime))

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/event/PushEventListener.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/event/PushEventListener.java
@@ -6,11 +6,8 @@ import com.woowacourse.smody.push.domain.PushCase;
 import com.woowacourse.smody.push.strategy.PushStrategy;
 import java.util.List;
 import java.util.Map;
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/repository/PushNotificationRepository.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/repository/PushNotificationRepository.java
@@ -6,6 +6,7 @@ import com.woowacourse.smody.push.domain.PushStatus;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,7 +16,9 @@ public interface PushNotificationRepository extends JpaRepository<PushNotificati
 
     Optional<PushNotification> findByPathIdAndPushStatus(Long pathId, PushStatus pushStatus);
 
-    void deleteByMember(Member member);
+    @Modifying
+    @Query("delete from PushNotification pn where pn.member = :member")
+    void deleteByMember(@Param("member") Member member);
 
     @Query("select pn from PushNotification pn where pn.member = :member and pn.pushStatus = :pushStatus "
             + "order by pn.pushTime desc")

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/repository/PushSubscriptionRepository.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/repository/PushSubscriptionRepository.java
@@ -5,6 +5,9 @@ import com.woowacourse.smody.push.domain.PushSubscription;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PushSubscriptionRepository extends JpaRepository<PushSubscription, Long> {
 
@@ -14,5 +17,7 @@ public interface PushSubscriptionRepository extends JpaRepository<PushSubscripti
 
     List<PushSubscription> findByMemberIn(List<Member> members);
 
-    void deleteByMember(Member member);
+    @Modifying
+    @Query("delete from PushSubscription ps where ps.member = :member")
+    void deleteByMember(@Param("member") Member member);
 }

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/strategy/ChallengePushStrategy.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/strategy/ChallengePushStrategy.java
@@ -1,10 +1,5 @@
 package com.woowacourse.smody.push.strategy;
 
-import java.time.LocalDateTime;
-
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.woowacourse.smody.challenge.domain.Challenge;
 import com.woowacourse.smody.cycle.domain.Cycle;
 import com.woowacourse.smody.cycle.service.CycleService;
@@ -12,8 +7,10 @@ import com.woowacourse.smody.push.domain.PushCase;
 import com.woowacourse.smody.push.domain.PushNotification;
 import com.woowacourse.smody.push.domain.PushStatus;
 import com.woowacourse.smody.push.service.PushNotificationService;
-
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor

--- a/backend/smody/src/main/java/com/woowacourse/smody/ui/admin/controller/LogView.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/ui/admin/controller/LogView.java
@@ -1,13 +1,5 @@
 package com.woowacourse.smody.ui.admin.controller;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
-
-import javax.annotation.security.PermitAll;
-
 import com.vaadin.flow.component.Unit;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
@@ -16,7 +8,12 @@ import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.woowacourse.smody.ui.admin.MenuLayout;
-
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import javax.annotation.security.PermitAll;
 import lombok.extern.slf4j.Slf4j;
 
 @PageTitle("log")

--- a/backend/smody/src/test/java/com/woowacourse/smody/acceptance/AcceptanceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/acceptance/AcceptanceTest.java
@@ -1,18 +1,16 @@
 package com.woowacourse.smody.acceptance;
 
+import com.woowacourse.smody.auth.dto.LoginRequest;
+import com.woowacourse.smody.auth.service.OauthService;
+import com.woowacourse.smody.member.domain.Member;
+import com.woowacourse.smody.support.isoloation.SmodyTestEnvironmentExtension;
+import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
-
-import com.woowacourse.smody.auth.dto.LoginRequest;
-import com.woowacourse.smody.auth.service.OauthService;
-import com.woowacourse.smody.member.domain.Member;
-import com.woowacourse.smody.support.isoloation.SmodyTestEnvironmentExtension;
-
-import io.restassured.RestAssured;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @ExtendWith(SmodyTestEnvironmentExtension.class)

--- a/backend/smody/src/test/java/com/woowacourse/smody/challenge/domain/ChallengingRecordTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/challenge/domain/ChallengingRecordTest.java
@@ -1,6 +1,6 @@
 package com.woowacourse.smody.challenge.domain;
 
-import static com.woowacourse.smody.support.ResourceFixture.*;
+import static com.woowacourse.smody.support.ResourceFixture.이미지;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/backend/smody/src/test/java/com/woowacourse/smody/comment/domain/CommentTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/comment/domain/CommentTest.java
@@ -1,12 +1,7 @@
 package com.woowacourse.smody.comment.domain;
 
-import static com.woowacourse.smody.support.ResourceFixture.*;
-import static org.assertj.core.api.Assertions.*;
-
-import java.time.LocalDateTime;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import static com.woowacourse.smody.support.ResourceFixture.이미지;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.smody.challenge.domain.Challenge;
 import com.woowacourse.smody.cycle.domain.Cycle;
@@ -15,6 +10,9 @@ import com.woowacourse.smody.cycle.domain.Progress;
 import com.woowacourse.smody.exception.BusinessException;
 import com.woowacourse.smody.exception.ExceptionData;
 import com.woowacourse.smody.member.domain.Member;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 class CommentTest {
 

--- a/backend/smody/src/test/java/com/woowacourse/smody/comment/service/CommentServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/comment/service/CommentServiceTest.java
@@ -18,9 +18,6 @@ import com.woowacourse.smody.support.IntegrationTest;
 import com.woowacourse.smody.support.ResourceFixture;
 import java.time.LocalDateTime;
 import java.util.Optional;
-
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/backend/smody/src/test/java/com/woowacourse/smody/cycle/controller/CycleControllerTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/cycle/controller/CycleControllerTest.java
@@ -1,24 +1,25 @@
 package com.woowacourse.smody.cycle.controller;
 
-import static com.woowacourse.smody.support.ResourceFixture.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.ResultActions;
+import static com.woowacourse.smody.support.ResourceFixture.MULTIPART_FILE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.woowacourse.smody.auth.dto.TokenPayload;
 import com.woowacourse.smody.cycle.dto.CycleDetailResponse;
@@ -34,6 +35,14 @@ import com.woowacourse.smody.db_support.PagingParams;
 import com.woowacourse.smody.exception.BusinessException;
 import com.woowacourse.smody.exception.ExceptionData;
 import com.woowacourse.smody.support.ControllerTest;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
 
 public class CycleControllerTest extends ControllerTest {
 

--- a/backend/smody/src/test/java/com/woowacourse/smody/cycle/domain/CycleTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/cycle/domain/CycleTest.java
@@ -1,23 +1,22 @@
 package com.woowacourse.smody.cycle.domain;
 
-import static com.woowacourse.smody.support.ResourceFixture.*;
-import static org.assertj.core.api.Assertions.*;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.ValueSource;
+import static com.woowacourse.smody.support.ResourceFixture.이미지;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.smody.challenge.domain.Challenge;
 import com.woowacourse.smody.exception.BusinessException;
 import com.woowacourse.smody.exception.ExceptionData;
 import com.woowacourse.smody.member.domain.Member;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class CycleTest {
 

--- a/backend/smody/src/test/java/com/woowacourse/smody/cycle/repository/CycleDetailRepositoryTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/cycle/repository/CycleDetailRepositoryTest.java
@@ -1,15 +1,10 @@
 package com.woowacourse.smody.cycle.repository;
 
-import static com.woowacourse.smody.support.ResourceFixture.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import static com.woowacourse.smody.support.ResourceFixture.미라클_모닝_ID;
+import static com.woowacourse.smody.support.ResourceFixture.이미지;
+import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.smody.cycle.domain.Cycle;
 import com.woowacourse.smody.cycle.domain.CycleDetail;
@@ -19,6 +14,11 @@ import com.woowacourse.smody.feed.domain.Feed;
 import com.woowacourse.smody.feed.repository.FeedRepository;
 import com.woowacourse.smody.support.RepositoryTest;
 import com.woowacourse.smody.support.ResourceFixture;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 class CycleDetailRepositoryTest extends RepositoryTest {
 

--- a/backend/smody/src/test/java/com/woowacourse/smody/cycle/repository/CycleRepositoryTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/cycle/repository/CycleRepositoryTest.java
@@ -2,24 +2,23 @@ package com.woowacourse.smody.cycle.repository;
 
 import static com.woowacourse.smody.support.ResourceFixture.미라클_모닝_ID;
 import static com.woowacourse.smody.support.ResourceFixture.스모디_방문하기_ID;
+import static com.woowacourse.smody.support.ResourceFixture.오늘의_운동_ID;
+import static com.woowacourse.smody.support.ResourceFixture.이미지;
 import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.smody.challenge.domain.ChallengingRecord;
 import com.woowacourse.smody.cycle.domain.Cycle;
 import com.woowacourse.smody.cycle.domain.CycleDetail;
-import com.woowacourse.smody.image.domain.Image;
+import com.woowacourse.smody.member.domain.Member;
 import com.woowacourse.smody.support.RepositoryTest;
 import com.woowacourse.smody.support.ResourceFixture;
 import java.time.LocalDateTime;
 import java.util.List;
-import javax.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.mock.web.MockMultipartFile;
 
 class CycleRepositoryTest extends RepositoryTest {
 
@@ -28,9 +27,6 @@ class CycleRepositoryTest extends RepositoryTest {
 
     @Autowired
     private ResourceFixture fixture;
-
-    @Autowired
-    private EntityManager em;
 
     @DisplayName("startTime 이 기준시간 이후인 사이클을 조회한다.")
     @Test
@@ -59,8 +55,6 @@ class CycleRepositoryTest extends RepositoryTest {
 
         // when
         cycle.increaseProgress(now.plusSeconds(60L), 이미지, "인증 완료");
-        em.flush();
-        em.clear();
 
         // then
         List<CycleDetail> cycleDetails = cycleRepository.findById(cycle.getId()).get().getCycleDetails();

--- a/backend/smody/src/test/java/com/woowacourse/smody/cycle/repository/CycleRepositoryTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/cycle/repository/CycleRepositoryTest.java
@@ -1,22 +1,25 @@
 package com.woowacourse.smody.cycle.repository;
 
-import static com.woowacourse.smody.support.ResourceFixture.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import javax.persistence.EntityManager;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import static com.woowacourse.smody.support.ResourceFixture.미라클_모닝_ID;
+import static com.woowacourse.smody.support.ResourceFixture.스모디_방문하기_ID;
+import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.smody.cycle.domain.Cycle;
 import com.woowacourse.smody.cycle.domain.CycleDetail;
+import com.woowacourse.smody.image.domain.Image;
 import com.woowacourse.smody.support.RepositoryTest;
 import com.woowacourse.smody.support.ResourceFixture;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockMultipartFile;
 
 class CycleRepositoryTest extends RepositoryTest {
 
@@ -66,5 +69,27 @@ class CycleRepositoryTest extends RepositoryTest {
                 () -> assertThat(cycleDetails.get(0).getProgressImage()).isEqualTo("image.jpg"),
                 () -> assertThat(cycleDetails.get(0).getDescription()).isEqualTo("인증 완료")
         );
+    }
+
+    @DisplayName("회원의 성공 회수를 포함한 사이클을 기준시간 이후로 조회한다.")
+    @Test
+    void findByMemberAfterTimeWithSuccessCount() {
+        LocalDateTime now = LocalDateTime.now();
+        Cycle inProgress1 = fixture.사이클_생성_NOTHING(조조그린_ID, 스모디_방문하기_ID, now.minusHours(1));
+        fixture.사이클_생성_FIRST(조조그린_ID, 스모디_방문하기_ID, now.minusDays(3L));
+        fixture.사이클_생성_SUCCESS(조조그린_ID, 스모디_방문하기_ID, now.minusDays(3L));
+        Cycle inProgress2 = fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝_ID, now.minusHours(2));
+        fixture.사이클_생성_SECOND(조조그린_ID, 미라클_모닝_ID, now.minusDays(4L));
+        fixture.사이클_생성_SUCCESS(조조그린_ID, 미라클_모닝_ID, now.minusDays(3L));
+        fixture.사이클_생성_SUCCESS(조조그린_ID, 미라클_모닝_ID, now.minusDays(6L));
+        Cycle future = fixture.사이클_생성_NOTHING(조조그린_ID, 오늘의_운동_ID, now.plusSeconds(1L));
+        Member member = fixture.회원_조회(조조그린_ID);
+
+        // when
+        List<ChallengingRecord> actual = cycleRepository.findAllChallengingRecordByMemberAfterTime(member.getId(), now);
+
+        // then
+        assertThat(actual).map(ChallengingRecord::getSuccessCount)
+                .containsExactly(1, 2, 0);
     }
 }

--- a/backend/smody/src/test/java/com/woowacourse/smody/cycle/service/CycleServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/cycle/service/CycleServiceTest.java
@@ -1,27 +1,23 @@
 package com.woowacourse.smody.cycle.service;
 
-import static com.woowacourse.smody.support.ResourceFixture.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
-
-import com.woowacourse.smody.challenge.repository.ChallengeRepository;
-import java.time.LocalDateTime;
-import java.util.List;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
+import static com.woowacourse.smody.support.ResourceFixture.FORMATTER;
+import static com.woowacourse.smody.support.ResourceFixture.JPA_공부_ID;
+import static com.woowacourse.smody.support.ResourceFixture.MULTIPART_FILE;
+import static com.woowacourse.smody.support.ResourceFixture.미라클_모닝_ID;
+import static com.woowacourse.smody.support.ResourceFixture.스모디_방문하기_ID;
+import static com.woowacourse.smody.support.ResourceFixture.알고리즘_풀기_ID;
+import static com.woowacourse.smody.support.ResourceFixture.알파_ID;
+import static com.woowacourse.smody.support.ResourceFixture.오늘의_운동_ID;
+import static com.woowacourse.smody.support.ResourceFixture.이미지;
+import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 import com.woowacourse.smody.auth.dto.TokenPayload;
-import com.woowacourse.smody.db_support.PagingParams;
+import com.woowacourse.smody.challenge.repository.ChallengeRepository;
 import com.woowacourse.smody.cycle.domain.Cycle;
 import com.woowacourse.smody.cycle.domain.Progress;
 import com.woowacourse.smody.cycle.dto.CycleRequest;
@@ -31,11 +27,21 @@ import com.woowacourse.smody.cycle.dto.InProgressCycleResponse;
 import com.woowacourse.smody.cycle.dto.ProgressRequest;
 import com.woowacourse.smody.cycle.dto.ProgressResponse;
 import com.woowacourse.smody.cycle.dto.StatResponse;
+import com.woowacourse.smody.db_support.PagingParams;
 import com.woowacourse.smody.exception.BusinessException;
 import com.woowacourse.smody.exception.ExceptionData;
-import com.woowacourse.smody.image.domain.Image;
-import com.woowacourse.smody.image.strategy.ImgBBImageStrategy;
 import com.woowacourse.smody.support.IntegrationTest;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 public class CycleServiceTest extends IntegrationTest {
 

--- a/backend/smody/src/test/java/com/woowacourse/smody/cycle/service/CycleServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/cycle/service/CycleServiceTest.java
@@ -341,13 +341,23 @@ public class CycleServiceTest extends IntegrationTest {
 
         @DisplayName("챌린지들에 해당하는 진행 중인 모든 사이클을 조회")
         @Test
-        void searchInProgress() {
+        void searchInProgressByChallenges() {
             List<Cycle> cycles = cycleService.searchInProgressByChallenges(now, List.of(
                     challengeRepository.findById(스모디_방문하기_ID).get(),
                     challengeRepository.findById(미라클_모닝_ID).get())
             );
 
             assertThat(cycles).hasSize(2);
+        }
+
+        @DisplayName("챌린지에 해당하는 진행 중인 모든 사이클을 조회")
+        @Test
+        void serchInProgressByChallenege() {
+            List<Cycle> cycles = cycleService.searchInProgressByChallenge(
+                    now, challengeRepository.findById(스모디_방문하기_ID).get()
+            );
+
+            assertThat(cycles).hasSize(1);
         }
 
         @DisplayName("진행 중인 모든 사이클을 남은 인증 시간 기준으로 오름차순 정렬")

--- a/backend/smody/src/test/java/com/woowacourse/smody/cycle/service/CycleServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/cycle/service/CycleServiceTest.java
@@ -448,6 +448,7 @@ public class CycleServiceTest extends IntegrationTest {
             //given
             PagingParams pagingParams = new PagingParams("startTime", null, 0L, null);
 
+            System.out.println("====");
             // when
             List<FilteredCycleHistoryResponse> historyResponses = cycleQueryService.findAllByMemberAndChallenge(
                     tokenPayload, 스모디_방문하기_ID, pagingParams);

--- a/backend/smody/src/test/java/com/woowacourse/smody/feed/repository/FeedRepositoryTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/feed/repository/FeedRepositoryTest.java
@@ -6,10 +6,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.woowacourse.smody.comment.domain.Comment;
 import com.woowacourse.smody.comment.repository.CommentRepository;
-import com.woowacourse.smody.cycle.domain.Progress;
-import com.woowacourse.smody.db_support.PagingParams;
 import com.woowacourse.smody.cycle.domain.Cycle;
 import com.woowacourse.smody.cycle.domain.CycleDetail;
+import com.woowacourse.smody.cycle.domain.Progress;
+import com.woowacourse.smody.db_support.PagingParams;
 import com.woowacourse.smody.feed.domain.Feed;
 import com.woowacourse.smody.support.RepositoryTest;
 import com.woowacourse.smody.support.ResourceFixture;

--- a/backend/smody/src/test/java/com/woowacourse/smody/image/ImgBBImageStrategyTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/image/ImgBBImageStrategyTest.java
@@ -1,16 +1,15 @@
 package com.woowacourse.smody.image;
 
-import static org.assertj.core.api.Assertions.*;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.smody.exception.BusinessException;
 import com.woowacourse.smody.exception.ExceptionData;
 import com.woowacourse.smody.image.strategy.ImageStrategy;
 import com.woowacourse.smody.image.strategy.ImgBBImageStrategy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 class ImgBBImageStrategyTest {
 

--- a/backend/smody/src/test/java/com/woowacourse/smody/member/service/MemberServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/member/service/MemberServiceTest.java
@@ -1,23 +1,14 @@
 package com.woowacourse.smody.member.service;
 
-import static com.woowacourse.smody.support.ResourceFixture.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
-
-import java.time.LocalDateTime;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.annotation.Rollback;
+import static com.woowacourse.smody.support.ResourceFixture.MULTIPART_FILE;
+import static com.woowacourse.smody.support.ResourceFixture.미라클_모닝_ID;
+import static com.woowacourse.smody.support.ResourceFixture.이미지;
+import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 import com.woowacourse.smody.auth.dto.TokenPayload;
 import com.woowacourse.smody.cycle.domain.Cycle;
@@ -32,6 +23,16 @@ import com.woowacourse.smody.push.domain.PushCase;
 import com.woowacourse.smody.push.repository.PushNotificationRepository;
 import com.woowacourse.smody.push.repository.PushSubscriptionRepository;
 import com.woowacourse.smody.support.IntegrationTest;
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Rollback;
 
 class MemberServiceTest extends IntegrationTest {
 

--- a/backend/smody/src/test/java/com/woowacourse/smody/member/service/MemberServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/member/service/MemberServiceTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.smody.member.service;
 
 import static com.woowacourse.smody.support.ResourceFixture.MULTIPART_FILE;
 import static com.woowacourse.smody.support.ResourceFixture.미라클_모닝_ID;
+import static com.woowacourse.smody.support.ResourceFixture.오늘의_운동_ID;
 import static com.woowacourse.smody.support.ResourceFixture.이미지;
 import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -99,8 +100,10 @@ class MemberServiceTest extends IntegrationTest {
     void withdraw() {
         // given
         TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
-        Cycle cycle = fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝_ID, LocalDateTime.now());
-        cycle.increaseProgress(LocalDateTime.now(), 이미지, "인증 완료");
+        Cycle cycle1 = fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝_ID, LocalDateTime.now());
+        Cycle cycle2 = fixture.사이클_생성_NOTHING(조조그린_ID, 오늘의_운동_ID, LocalDateTime.now());
+        cycle1.increaseProgress(LocalDateTime.now(), 이미지, "인증 완료");
+        cycle2.increaseProgress(LocalDateTime.now(), 이미지, "인증 완료");
         fixture.알림_구독(조조그린_ID, "endpoint");
         fixture.발송_예정_알림_생성(조조그린_ID, null, LocalDateTime.now(), PushCase.SUBSCRIPTION);
 

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/PushSchedulerTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/PushSchedulerTest.java
@@ -1,18 +1,11 @@
 package com.woowacourse.smody.push;
 
-import static com.woowacourse.smody.support.ResourceFixture.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
-import org.springframework.beans.factory.annotation.Autowired;
+import static com.woowacourse.smody.support.ResourceFixture.더즈_ID;
+import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
+import static com.woowacourse.smody.support.ResourceFixture.토닉_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
 
 import com.woowacourse.smody.member.domain.Member;
 import com.woowacourse.smody.member.repository.MemberRepository;
@@ -23,6 +16,13 @@ import com.woowacourse.smody.push.domain.PushSubscription;
 import com.woowacourse.smody.push.repository.PushNotificationRepository;
 import com.woowacourse.smody.push.service.PushSubscriptionService;
 import com.woowacourse.smody.support.IntegrationTest;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
 
 class PushSchedulerTest extends IntegrationTest {
 

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/event/ChallengePushEventListenerTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/event/ChallengePushEventListenerTest.java
@@ -1,19 +1,14 @@
 package com.woowacourse.smody.push.event;
 
-import static com.woowacourse.smody.support.ResourceFixture.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
-
-import java.time.LocalDateTime;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import static com.woowacourse.smody.support.ResourceFixture.FORMATTER;
+import static com.woowacourse.smody.support.ResourceFixture.MULTIPART_FILE;
+import static com.woowacourse.smody.support.ResourceFixture.미라클_모닝_ID;
+import static com.woowacourse.smody.support.ResourceFixture.스모디_방문하기_ID;
+import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 import com.woowacourse.smody.auth.dto.TokenPayload;
 import com.woowacourse.smody.cycle.domain.Cycle;
@@ -25,6 +20,13 @@ import com.woowacourse.smody.push.domain.PushNotification;
 import com.woowacourse.smody.push.domain.PushStatus;
 import com.woowacourse.smody.push.repository.PushNotificationRepository;
 import com.woowacourse.smody.support.IntegrationTest;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 class ChallengePushEventListenerTest extends IntegrationTest {
 

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/event/CommentPushEventListenerTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/event/CommentPushEventListenerTest.java
@@ -1,17 +1,10 @@
 package com.woowacourse.smody.push.event;
 
-import static com.woowacourse.smody.support.ResourceFixture.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import static com.woowacourse.smody.support.ResourceFixture.더즈_ID;
+import static com.woowacourse.smody.support.ResourceFixture.미라클_모닝_ID;
+import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.smody.auth.dto.TokenPayload;
 import com.woowacourse.smody.comment.dto.CommentRequest;
@@ -23,6 +16,13 @@ import com.woowacourse.smody.push.domain.PushNotification;
 import com.woowacourse.smody.push.domain.PushStatus;
 import com.woowacourse.smody.push.repository.PushNotificationRepository;
 import com.woowacourse.smody.support.IntegrationTest;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 class CommentPushEventListenerTest extends IntegrationTest {
 

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/event/EventExceptionTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/event/EventExceptionTest.java
@@ -1,22 +1,13 @@
 package com.woowacourse.smody.push.event;
 
-import static com.woowacourse.smody.support.ResourceFixture.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import static com.woowacourse.smody.support.ResourceFixture.더즈_ID;
+import static com.woowacourse.smody.support.ResourceFixture.미라클_모닝_ID;
+import static com.woowacourse.smody.support.ResourceFixture.스모디_방문하기_ID;
+import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willThrow;
 
 import com.woowacourse.smody.auth.dto.TokenPayload;
 import com.woowacourse.smody.comment.domain.Comment;
@@ -32,6 +23,16 @@ import com.woowacourse.smody.push.dto.SubscriptionRequest;
 import com.woowacourse.smody.push.repository.PushNotificationRepository;
 import com.woowacourse.smody.push.service.PushSubscriptionService;
 import com.woowacourse.smody.support.IntegrationTest;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @DisplayName("알림 이벤트에 예외가 발생해도 ")
 class EventExceptionTest extends IntegrationTest {

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/event/SubscriptionPushEventListenerTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/event/SubscriptionPushEventListenerTest.java
@@ -1,15 +1,8 @@
 package com.woowacourse.smody.push.event;
 
-import static com.woowacourse.smody.support.ResourceFixture.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.concurrent.TimeUnit;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.smody.auth.dto.TokenPayload;
 import com.woowacourse.smody.push.domain.PushCase;
@@ -19,6 +12,11 @@ import com.woowacourse.smody.push.dto.SubscriptionRequest;
 import com.woowacourse.smody.push.repository.PushNotificationRepository;
 import com.woowacourse.smody.push.service.PushSubscriptionService;
 import com.woowacourse.smody.support.IntegrationTest;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 class SubscriptionPushEventListenerTest extends IntegrationTest {
 

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/repository/PushSubscriptionRepositoryTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/repository/PushSubscriptionRepositoryTest.java
@@ -11,8 +11,6 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
 class PushSubscriptionRepositoryTest extends RepositoryTest {
 

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/strategy/ChallengePushStrategyTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/strategy/ChallengePushStrategyTest.java
@@ -1,15 +1,10 @@
 package com.woowacourse.smody.push.strategy;
 
-import static com.woowacourse.smody.support.ResourceFixture.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import static com.woowacourse.smody.support.ResourceFixture.FORMATTER;
+import static com.woowacourse.smody.support.ResourceFixture.미라클_모닝_ID;
+import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.smody.cycle.domain.Cycle;
 import com.woowacourse.smody.push.domain.PushCase;
@@ -17,6 +12,11 @@ import com.woowacourse.smody.push.domain.PushNotification;
 import com.woowacourse.smody.push.domain.PushStatus;
 import com.woowacourse.smody.push.repository.PushNotificationRepository;
 import com.woowacourse.smody.support.IntegrationTest;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 class ChallengePushStrategyTest extends IntegrationTest {
 

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/strategy/CommentPushStrategyTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/strategy/CommentPushStrategyTest.java
@@ -1,6 +1,9 @@
 package com.woowacourse.smody.push.strategy;
 
-import static com.woowacourse.smody.support.ResourceFixture.*;
+import static com.woowacourse.smody.support.ResourceFixture.FORMATTER;
+import static com.woowacourse.smody.support.ResourceFixture.더즈_ID;
+import static com.woowacourse.smody.support.ResourceFixture.미라클_모닝_ID;
+import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;

--- a/backend/smody/src/test/java/com/woowacourse/smody/support/IntegrationTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/support/IntegrationTest.java
@@ -1,13 +1,12 @@
 package com.woowacourse.smody.support;
 
+import com.woowacourse.smody.image.strategy.ImageStrategy;
+import com.woowacourse.smody.push.service.WebPushService;
+import com.woowacourse.smody.support.isoloation.SmodyTestEnvironmentExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-
-import com.woowacourse.smody.image.strategy.ImageStrategy;
-import com.woowacourse.smody.push.service.WebPushService;
-import com.woowacourse.smody.support.isoloation.SmodyTestEnvironmentExtension;
 
 @SpringBootTest
 @ExtendWith(SmodyTestEnvironmentExtension.class)

--- a/backend/smody/src/test/java/com/woowacourse/smody/support/RepositoryTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/support/RepositoryTest.java
@@ -1,13 +1,11 @@
 package com.woowacourse.smody.support;
 
-import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.woowacourse.smody.support.isoloation.SmodyDatabaseManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-
-import com.woowacourse.smody.support.isoloation.SmodyDatabaseManager;
 
 @DataJpaTest(showSql = false)
 @Import({ResourceFixture.class, SmodyDatabaseManager.class, QueryFactoryTestConfig.class})

--- a/backend/smody/src/test/java/com/woowacourse/smody/support/ResourceFixture.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/support/ResourceFixture.java
@@ -1,14 +1,5 @@
 package com.woowacourse.smody.support;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.woowacourse.smody.challenge.domain.Challenge;
 import com.woowacourse.smody.challenge.repository.ChallengeRepository;
 import com.woowacourse.smody.comment.domain.Comment;
@@ -26,6 +17,13 @@ import com.woowacourse.smody.push.domain.PushStatus;
 import com.woowacourse.smody.push.domain.PushSubscription;
 import com.woowacourse.smody.push.repository.PushNotificationRepository;
 import com.woowacourse.smody.push.repository.PushSubscriptionRepository;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Component
 @SuppressWarnings("NonAsciiCharacters")

--- a/backend/smody/src/test/java/com/woowacourse/smody/support/isoloation/SmodyDatabaseManager.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/support/isoloation/SmodyDatabaseManager.java
@@ -1,17 +1,14 @@
 package com.woowacourse.smody.support.isoloation;
 
+import com.woowacourse.smody.challenge.domain.Challenge;
+import com.woowacourse.smody.member.domain.Member;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import javax.persistence.Entity;
 import javax.persistence.EntityManager;
 import javax.persistence.metamodel.EntityType;
-
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.woowacourse.smody.challenge.domain.Challenge;
-import com.woowacourse.smody.member.domain.Member;
 
 @Component
 public class SmodyDatabaseManager {


### PR DESCRIPTION
[노션 정리](https://www.notion.so/woowa/48a01236b3394bd99634533d08f782b4)

- 모든 챌린지 조회
  - 모든 사이클이 아닌 챌린지에 해당하는 사이클만 조회하도록 수정
- 챌린지 하나 상세 조회
  - where 절에 챌린지 조건 추가
- 챌린지 참가자 목록 조회
  - n+1 문제 해결
- 나의 모든 진행 중인 사이클 조회
  - n+1 문제 해결
- 나의 특정 챌린지에 대한 전체 사이클 조회
  - n+1 문제 해결
- 모든 피드 조회
  - cross join을 inner join으로 해결
- 모든 댓글 조회
  - 피드 조회 쿼리 삭제
- 회원 탈퇴
  - 회원과 관련된 데이터 삭제 시 n+1 문제 해결

