### PR TITLE
hotfix : (be) mysql 쿼리 에러

### DIFF
--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/repository/DynamicCycleRepositoryImpl.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/repository/DynamicCycleRepositoryImpl.java
@@ -95,7 +95,7 @@ public class DynamicCycleRepositoryImpl implements DynamicCycleRepository {
     private Expression<Long> successCountSubQuery() {
         QCycle subCycle = new QCycle("subCycle");
         return ExpressionUtils.as(
-                JPAExpressions.select(count(cycle.id))
+                JPAExpressions.select(count(subCycle.id))
                         .from(subCycle)
                         .where(DynamicQuery.builder()
                                 .and(() -> subCycle.challenge.eq(cycle.challenge))

--- a/frontend/src/components/CardGridContainer/useCardGridContainer.ts
+++ b/frontend/src/components/CardGridContainer/useCardGridContainer.ts
@@ -1,5 +1,4 @@
 import { useGetMyChallenges } from 'apis';
-import { indexedDB } from 'pwa/indexedDB';
 
 const useCardGridContainer = () => {
   const {
@@ -7,13 +6,7 @@ const useCardGridContainer = () => {
     hasNextPage,
     fetchNextPage,
     isFetching,
-  } = useGetMyChallenges({
-    useErrorBoundary: false,
-    onSuccess: (data) => {
-      const myChallenges = data.pages[0].data;
-      indexedDB.putPost('myChallenge', myChallenges);
-    },
-  });
+  } = useGetMyChallenges();
 
   return {
     myChallengeInfiniteData,

--- a/frontend/src/pwa/indexedDB.js
+++ b/frontend/src/pwa/indexedDB.js
@@ -27,10 +27,6 @@ class IndexedDB {
         db.createObjectStore('challenge', {
           keyPath: 'challengeId',
         });
-
-        db.createObjectStore('myChallenge', {
-          keyPath: 'challengeId',
-        });
       };
 
       request.onsuccess = () => {


### PR DESCRIPTION
querydsl 에서 서브 쿼리를 날릴 때 별칭으로 인한 에러 발생
```java
private Expression<Long> successCountSubQuery() {
    QCycle subCycle = new QCycle("subCycle");
    return ExpressionUtils.as(
            JPAExpressions.select(count(subCycle.id))
                    .from(subCycle)
                    .where(DynamicQuery.builder()
                            .and(() -> subCycle.challenge.eq(cycle.challenge))
                            .and(() -> subCycle.progress.eq(Progress.SUCCESS))
                            .build()
                    ),
            "successCount");
    }
```

```java
private Expression<Long> successCountSubQuery() {
    QCycle subCycle = new QCycle("subCycle");
    return ExpressionUtils.as(
            JPAExpressions.select(count(cycle.id))
                    .from(subCycle)
                    .where(DynamicQuery.builder()
                            .and(() -> subCycle.challenge.eq(cycle.challenge))
                            .and(() -> subCycle.progress.eq(Progress.SUCCESS))
                            .build()
                    ),
            "successCount");
    }
```