### PR TITLE
fix: (be) 진행 중인 사이클에서 성공횟수 오류 수정

### DIFF
--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/repository/DynamicCycleRepositoryImpl.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/repository/DynamicCycleRepositoryImpl.java
@@ -5,6 +5,7 @@ import static com.woowacourse.smody.challenge.domain.QChallenge.challenge;
 import static com.woowacourse.smody.cycle.domain.QCycle.cycle;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.ExpressionUtils;
@@ -19,6 +20,8 @@ import com.woowacourse.smody.db_support.DynamicQuery;
 import com.woowacourse.smody.db_support.PagingParams;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -80,9 +83,10 @@ public class DynamicCycleRepositoryImpl implements DynamicCycleRepository {
                 .join(cycle.challenge, challenge).fetchJoin()
                 .where(DynamicQuery.builder()
                         .and(() -> cycle.member.id.eq(memberId))
-                        .and(() -> cycle.startTime.after(time.minusDays(Cycle.DAYS)))
+                        .and(() -> cycle.startTime.after(time))
                         .build()
-                ).fetch();
+                )
+            .fetch();
     }
 
     private ConstructorExpression<ChallengingRecord> challengingRecordConstructor() {
@@ -97,10 +101,10 @@ public class DynamicCycleRepositoryImpl implements DynamicCycleRepository {
         return ExpressionUtils.as(
                 JPAExpressions.select(count(subCycle.id))
                         .from(subCycle)
-                        .where(DynamicQuery.builder()
-                                .and(() -> subCycle.challenge.eq(cycle.challenge))
-                                .and(() -> subCycle.progress.eq(Progress.SUCCESS))
-                                .build()
+                        .where(new BooleanBuilder()
+                            .and(subCycle.challenge.eq(cycle.challenge))
+                            .and(subCycle.progress.eq(Progress.SUCCESS))
+                            .and(subCycle.member.eq(cycle.member))
                         ),
                 "successCount");
     }

--- a/backend/smody/src/test/java/com/woowacourse/smody/cycle/repository/CycleRepositoryTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/cycle/repository/CycleRepositoryTest.java
@@ -1,24 +1,21 @@
 package com.woowacourse.smody.cycle.repository;
 
-import static com.woowacourse.smody.support.ResourceFixture.미라클_모닝_ID;
-import static com.woowacourse.smody.support.ResourceFixture.스모디_방문하기_ID;
-import static com.woowacourse.smody.support.ResourceFixture.오늘의_운동_ID;
-import static com.woowacourse.smody.support.ResourceFixture.이미지;
-import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import static com.woowacourse.smody.support.ResourceFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import com.woowacourse.smody.challenge.domain.ChallengingRecord;
 import com.woowacourse.smody.cycle.domain.Cycle;
 import com.woowacourse.smody.cycle.domain.CycleDetail;
-import com.woowacourse.smody.member.domain.Member;
 import com.woowacourse.smody.support.RepositoryTest;
 import com.woowacourse.smody.support.ResourceFixture;
-import java.time.LocalDateTime;
-import java.util.List;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 class CycleRepositoryTest extends RepositoryTest {
 
@@ -69,21 +66,29 @@ class CycleRepositoryTest extends RepositoryTest {
     @Test
     void findByMemberAfterTimeWithSuccessCount() {
         LocalDateTime now = LocalDateTime.now();
-        Cycle inProgress1 = fixture.사이클_생성_NOTHING(조조그린_ID, 스모디_방문하기_ID, now.minusHours(1));
-        fixture.사이클_생성_FIRST(조조그린_ID, 스모디_방문하기_ID, now.minusDays(3L));
-        fixture.사이클_생성_SUCCESS(조조그린_ID, 스모디_방문하기_ID, now.minusDays(3L));
-        Cycle inProgress2 = fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝_ID, now.minusHours(2));
+        fixture.사이클_생성_NOTHING(조조그린_ID, 스모디_방문하기_ID, now.minusHours(1));
+        fixture.사이클_생성_FIRST(조조그린_ID, 스모디_방문하기_ID, now.minusDays(2L));
+        fixture.사이클_생성_SUCCESS(조조그린_ID, 스모디_방문하기_ID, now.minusDays(2L));
+
+        fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝_ID, now.minusHours(2));
         fixture.사이클_생성_SECOND(조조그린_ID, 미라클_모닝_ID, now.minusDays(4L));
-        fixture.사이클_생성_SUCCESS(조조그린_ID, 미라클_모닝_ID, now.minusDays(3L));
+        fixture.사이클_생성_SUCCESS(조조그린_ID, 미라클_모닝_ID, now.minusDays(2L));
         fixture.사이클_생성_SUCCESS(조조그린_ID, 미라클_모닝_ID, now.minusDays(6L));
-        Cycle future = fixture.사이클_생성_NOTHING(조조그린_ID, 오늘의_운동_ID, now.plusSeconds(1L));
-        Member member = fixture.회원_조회(조조그린_ID);
+
+        fixture.사이클_생성_NOTHING(조조그린_ID, 오늘의_운동_ID, now.plusSeconds(1L));
+
+        fixture.사이클_생성_SUCCESS(더즈_ID, 오늘의_운동_ID, now.plusSeconds(1L));
 
         // when
-        List<ChallengingRecord> actual = cycleRepository.findAllChallengingRecordByMemberAfterTime(member.getId(), now);
+        List<ChallengingRecord> actual = cycleRepository.findAllChallengingRecordByMemberAfterTime(조조그린_ID, now.minusDays(3));
+
+        for (ChallengingRecord challengingRecord : actual) {
+            String name = challengingRecord.getChallenge().getName();
+            System.out.println(name + challengingRecord.getSuccessCount());
+        }
 
         // then
         assertThat(actual).map(ChallengingRecord::getSuccessCount)
-                .containsExactly(1, 2, 0);
+                .containsExactly(1, 1, 1, 2, 2, 0);
     }
 }

--- a/backend/smody/src/test/java/com/woowacourse/smody/cycle/service/CycleServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/cycle/service/CycleServiceTest.java
@@ -1,15 +1,6 @@
 package com.woowacourse.smody.cycle.service;
 
-import static com.woowacourse.smody.support.ResourceFixture.FORMATTER;
-import static com.woowacourse.smody.support.ResourceFixture.JPA_공부_ID;
-import static com.woowacourse.smody.support.ResourceFixture.MULTIPART_FILE;
-import static com.woowacourse.smody.support.ResourceFixture.미라클_모닝_ID;
-import static com.woowacourse.smody.support.ResourceFixture.스모디_방문하기_ID;
-import static com.woowacourse.smody.support.ResourceFixture.알고리즘_풀기_ID;
-import static com.woowacourse.smody.support.ResourceFixture.알파_ID;
-import static com.woowacourse.smody.support.ResourceFixture.오늘의_운동_ID;
-import static com.woowacourse.smody.support.ResourceFixture.이미지;
-import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
+import static com.woowacourse.smody.support.ResourceFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -246,14 +237,18 @@ public class CycleServiceTest extends IntegrationTest {
     @Test
     void findAllInProgressOfMine() {
         // given
-        Cycle inProgress1 = fixture.사이클_생성_NOTHING(조조그린_ID, 스모디_방문하기_ID, now.minusHours(1)); // 2, 1
+        fixture.사이클_생성_NOTHING(조조그린_ID, 스모디_방문하기_ID, now.minusHours(1)); // 2, 1
         fixture.사이클_생성_FIRST(조조그린_ID, 스모디_방문하기_ID, now.minusDays(3L));
         fixture.사이클_생성_SUCCESS(조조그린_ID, 스모디_방문하기_ID, now.minusDays(3L));
-        Cycle inProgress2 = fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝_ID, now.minusHours(2)); // 1, 2
+
+        fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝_ID, now.minusHours(2)); // 1, 2
         fixture.사이클_생성_SECOND(조조그린_ID, 미라클_모닝_ID, now.minusDays(4L));
         fixture.사이클_생성_SUCCESS(조조그린_ID, 미라클_모닝_ID, now.minusDays(3L));
         fixture.사이클_생성_SUCCESS(조조그린_ID, 미라클_모닝_ID, now.minusDays(6L));
-        Cycle future = fixture.사이클_생성_NOTHING(조조그린_ID, 오늘의_운동_ID, now.plusSeconds(1L)); // 3, 0
+
+        fixture.사이클_생성_SUCCESS(더즈_ID, 미라클_모닝_ID, now.minusDays(6L));
+
+        fixture.사이클_생성_NOTHING(조조그린_ID, 오늘의_운동_ID, now.plusSeconds(1L)); // 3, 0
 
         TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
 


### PR DESCRIPTION
```
    private Expression<Long> successCountSubQuery() {
        QCycle subCycle = new QCycle("subCycle");
        return ExpressionUtils.as(
                JPAExpressions.select(count(subCycle.id))
                        .from(subCycle)
                        .where(new BooleanBuilder()
                            .and(subCycle.challenge.eq(cycle.challenge))
                            .and(subCycle.progress.eq(Progress.SUCCESS))
                            .and(subCycle.member.eq(cycle.member))
                        ),
                "successCount");
    }
```
성공 횟수를 세는 서브 쿼리에서 member에 대한 필터링이 빠져 있었음