### PR TITLE
refactor: (fe) children이 사용된 컴포넌트에 PropsWithChildren 적용

### DIFF
--- a/frontend/src/components/@shared/ModalOverlay/index.tsx
+++ b/frontend/src/components/@shared/ModalOverlay/index.tsx
@@ -1,10 +1,14 @@
 import { ModalOverlayProps } from './type';
+import { PropsWithChildren } from 'react';
 import ReactDOM from 'react-dom';
 import styled, { css } from 'styled-components';
 
 import { Z_INDEX } from 'constants/css';
 
-export const ModalOverlay = ({ children, handleCloseModal }: ModalOverlayProps) => {
+export const ModalOverlay = ({
+  children,
+  handleCloseModal,
+}: PropsWithChildren<ModalOverlayProps>) => {
   return (
     <>
       {ReactDOM.createPortal(

--- a/frontend/src/components/@shared/ModalOverlay/type.ts
+++ b/frontend/src/components/@shared/ModalOverlay/type.ts
@@ -1,6 +1,3 @@
-import { ReactNode } from 'react';
-
 export interface ModalOverlayProps {
-  children: ReactNode;
   handleCloseModal(): void;
 }

--- a/frontend/src/components/BottomSheet/index.tsx
+++ b/frontend/src/components/BottomSheet/index.tsx
@@ -1,4 +1,5 @@
 import { BottomSheetContentProps, BottomSheetProps } from './type';
+import { PropsWithChildren } from 'react';
 import ReactDOM from 'react-dom';
 import styled, { css, keyframes } from 'styled-components';
 
@@ -8,7 +9,7 @@ export const BottomSheet = ({
   children,
   height,
   handleCloseBottomSheet,
-}: BottomSheetProps) => {
+}: PropsWithChildren<BottomSheetProps>) => {
   return (
     <>
       {ReactDOM.createPortal(

--- a/frontend/src/components/BottomSheet/type.ts
+++ b/frontend/src/components/BottomSheet/type.ts
@@ -1,7 +1,4 @@
-import { ReactNode } from 'react';
-
 export interface BottomSheetProps {
-  children: ReactNode;
   height?: string;
   handleCloseBottomSheet(): void;
 }

--- a/frontend/src/components/Dropdown/index.tsx
+++ b/frontend/src/components/Dropdown/index.tsx
@@ -1,5 +1,6 @@
 import { DropdownProps } from './type';
 import { useDropdown } from './useDropdown';
+import { PropsWithChildren } from 'react';
 import styled, { css } from 'styled-components';
 
 export const Dropdown = ({
@@ -9,7 +10,7 @@ export const Dropdown = ({
   children,
   updateNotificationCount,
   updateIsSubscribed,
-}: DropdownProps) => {
+}: PropsWithChildren<DropdownProps>) => {
   const { isDropdownToggled, showDropdownMenu, hideDropdownMenu, onSelectMenu } =
     useDropdown({ updateNotificationCount, updateIsSubscribed });
 

--- a/frontend/src/components/Dropdown/type.ts
+++ b/frontend/src/components/Dropdown/type.ts
@@ -4,7 +4,6 @@ export interface DropdownProps {
   disabled?: boolean;
   button: ReactNode;
   nonLinkableElement?: ReactNode;
-  children?: ReactNode;
   updateIsSubscribed: (updatedIsSubscribed: boolean) => void;
   updateNotificationCount: (updatedNotificationCount: number) => void;
 }

--- a/frontend/src/components/ErrorBoundary/index.tsx
+++ b/frontend/src/components/ErrorBoundary/index.tsx
@@ -1,5 +1,6 @@
 import { ErrorBoundaryProps, ErrorBoundaryState } from './type';
 import { AxiosError } from 'axios';
+import { PropsWithChildren } from 'react';
 import React from 'react';
 
 import { ERROR_MESSAGE } from 'constants/message';
@@ -11,16 +12,16 @@ const OFFLINE_ERROR_MESSAGE =
 const INITIAL_STATE = { hasError: false, errorCode: null, errorMessage: null };
 
 export class ErrorBoundary extends React.Component<
-  ErrorBoundaryProps,
+  PropsWithChildren<ErrorBoundaryProps>,
   ErrorBoundaryState
 > {
-  constructor(props: ErrorBoundaryProps) {
+  constructor(props: PropsWithChildren<ErrorBoundaryProps>) {
     super(props);
 
     this.state = INITIAL_STATE;
   }
 
-  componentDidUpdate(prevProps: ErrorBoundaryProps) {
+  componentDidUpdate(prevProps: PropsWithChildren<ErrorBoundaryProps>) {
     const { pathname: currentPathname } = this.props;
     const { pathname: prevPathname } = prevProps;
 

--- a/frontend/src/components/ErrorBoundary/type.ts
+++ b/frontend/src/components/ErrorBoundary/type.ts
@@ -10,7 +10,6 @@ export interface RenderFallbackParamsInterface {
 
 export interface ErrorBoundaryProps {
   pathname: string;
-  children: ReactNode;
   renderFallback: (renderFallbackParams: RenderFallbackParamsInterface) => ReactNode;
 }
 

--- a/frontend/src/components/InfiniteScroll/index.tsx
+++ b/frontend/src/components/InfiniteScroll/index.tsx
@@ -1,5 +1,5 @@
 import { InfiniteScrollProps } from './type';
-import { RefObject, useMemo, useRef } from 'react';
+import { RefObject, useMemo, useRef, PropsWithChildren } from 'react';
 import styled from 'styled-components';
 
 import useIntersect from 'hooks/useIntersect';
@@ -13,7 +13,7 @@ export const InfiniteScroll = ({
   isFetching,
   loader,
   threshold = 0.5,
-}: InfiniteScrollProps) => {
+}: PropsWithChildren<InfiniteScrollProps>) => {
   const rootRef = useRef() as RefObject<HTMLDivElement>;
 
   const options = useMemo(() => ({ root: rootRef.current, threshold }), []);

--- a/frontend/src/components/InfiniteScroll/type.ts
+++ b/frontend/src/components/InfiniteScroll/type.ts
@@ -1,7 +1,6 @@
 import { ReactNode } from 'react';
 
 export interface InfiniteScrollProps {
-  children: ReactNode;
   loadMore: () => void;
   hasMore?: boolean;
   isFetching: boolean;

--- a/frontend/src/components/LinkText/index.tsx
+++ b/frontend/src/components/LinkText/index.tsx
@@ -1,10 +1,17 @@
+import { PropsWithChildren } from 'react';
 import { Link } from 'react-router-dom';
 
 import { Text } from 'components/@shared/Text';
 
 import { LinkTextProps } from 'components/LinkText/type';
 
-export const LinkText = ({ children, to, color, size, fontWeight }: LinkTextProps) => {
+export const LinkText = ({
+  children,
+  to,
+  color,
+  size,
+  fontWeight,
+}: PropsWithChildren<LinkTextProps>) => {
   return (
     <Link to={to}>
       <Text color={color} size={size} fontWeight={fontWeight}>

--- a/frontend/src/components/LinkText/type.ts
+++ b/frontend/src/components/LinkText/type.ts
@@ -1,10 +1,7 @@
-import { ReactNode } from 'react';
-
 import { TextProps } from 'components/@shared/Text/type';
 
 export type FontSizeType = 10 | 11 | 12 | 14 | 16 | 20 | 24 | 32 | 40 | 48;
 
 export interface LinkTextProps extends TextProps {
-  children: ReactNode;
   to: string;
 }

--- a/frontend/src/components/ScrollToTop/index.tsx
+++ b/frontend/src/components/ScrollToTop/index.tsx
@@ -1,12 +1,12 @@
 import { ScrollToTopProps } from './type';
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 
-export class ScrollToTop extends React.Component<ScrollToTopProps> {
-  constructor(props: ScrollToTopProps) {
+export class ScrollToTop extends React.Component<PropsWithChildren<ScrollToTopProps>> {
+  constructor(props: PropsWithChildren<ScrollToTopProps>) {
     super(props);
   }
 
-  componentDidUpdate(prevProps: ScrollToTopProps) {
+  componentDidUpdate(prevProps: PropsWithChildren<ScrollToTopProps>) {
     const { pathname: prevPathname } = prevProps;
     const { pathname: currentPathname } = this.props;
 
@@ -17,6 +17,8 @@ export class ScrollToTop extends React.Component<ScrollToTopProps> {
   }
 
   render() {
-    return this.props.children;
+    const { children } = this.props;
+
+    return children;
   }
 }

--- a/frontend/src/components/ScrollToTop/type.ts
+++ b/frontend/src/components/ScrollToTop/type.ts
@@ -1,6 +1,3 @@
-import { ReactNode } from 'react';
-
 export interface ScrollToTopProps {
   pathname: string;
-  children: ReactNode;
 }

--- a/frontend/src/components/Title/index.tsx
+++ b/frontend/src/components/Title/index.tsx
@@ -1,4 +1,5 @@
 import useTitle from './useTitle';
+import { PropsWithChildren } from 'react';
 import { MdArrowBackIosNew } from 'react-icons/md';
 import styled from 'styled-components';
 
@@ -7,7 +8,7 @@ import useThemeContext from 'hooks/useThemeContext';
 import { FlexBox, Text } from 'components';
 import { TitleProps } from 'components/Title/type';
 
-export const Title = ({ text, linkTo, children }: TitleProps) => {
+export const Title = ({ text, linkTo, children }: PropsWithChildren<TitleProps>) => {
   const themeContext = useThemeContext();
   const { backToPreviousPage } = useTitle({ linkTo });
 

--- a/frontend/src/components/Title/type.ts
+++ b/frontend/src/components/Title/type.ts
@@ -1,9 +1,6 @@
-import { ReactNode } from 'react';
-
 export interface TitleProps {
   text: string;
   linkTo?: string;
-  children?: ReactNode;
 }
 
 export type UseTitleProps = Pick<TitleProps, 'linkTo'>;


### PR DESCRIPTION
close #410 

팀의 타입스크립트 컨벤션에 맞게 children이 사용된 컴포넌트의 경우 props의 타입을 PropsWithChildren 유틸 타입으로 wrapping해서 사용하도록 리팩터링 진행