### PR TITLE
feat : (be) 랭킹의 기간 조회

### DIFF
--- a/backend/smody/src/main/java/com/woowacourse/smody/ranking/controller/RankingPeriodController.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/ranking/controller/RankingPeriodController.java
@@ -1,0 +1,24 @@
+package com.woowacourse.smody.ranking.controller;
+
+import com.woowacourse.smody.ranking.dto.RankingPeriodResponse;
+import com.woowacourse.smody.ranking.service.RankingPeriodService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/ranking-periods")
+@RequiredArgsConstructor
+public class RankingPeriodController {
+
+    private final RankingPeriodService rankingPeriodService;
+
+    @GetMapping
+    public ResponseEntity<List<RankingPeriodResponse>> findAll() {
+        List<RankingPeriodResponse> rankingPeriodResponses = rankingPeriodService.findAll();
+        return ResponseEntity.ok(rankingPeriodResponses);
+    }
+}

--- a/backend/smody/src/main/java/com/woowacourse/smody/ranking/controller/RankingPeriodController.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/ranking/controller/RankingPeriodController.java
@@ -18,7 +18,7 @@ public class RankingPeriodController {
 
     @GetMapping
     public ResponseEntity<List<RankingPeriodResponse>> findAll() {
-        List<RankingPeriodResponse> rankingPeriodResponses = rankingPeriodService.findAll();
+        List<RankingPeriodResponse> rankingPeriodResponses = rankingPeriodService.findAllLatestOrder();
         return ResponseEntity.ok(rankingPeriodResponses);
     }
 }

--- a/backend/smody/src/main/java/com/woowacourse/smody/ranking/domain/Duration.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/ranking/domain/Duration.java
@@ -1,0 +1,6 @@
+package com.woowacourse.smody.ranking.domain;
+
+public enum Duration {
+
+    WEEK;
+}

--- a/backend/smody/src/main/java/com/woowacourse/smody/ranking/domain/RankingPeriod.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/ranking/domain/RankingPeriod.java
@@ -1,0 +1,36 @@
+package com.woowacourse.smody.ranking.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class RankingPeriod {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ranking_period_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private LocalDateTime startDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Duration duration;
+
+    public RankingPeriod(LocalDateTime startDate, Duration duration) {
+        this.startDate = startDate;
+        this.duration = duration;
+    }
+}

--- a/backend/smody/src/main/java/com/woowacourse/smody/ranking/dto/RankingPeriodResponse.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/ranking/dto/RankingPeriodResponse.java
@@ -1,0 +1,16 @@
+package com.woowacourse.smody.ranking.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class RankingPeriodResponse {
+
+    private Long rankingPeriodId;
+    private LocalDateTime startDate;
+    private String duration;
+}

--- a/backend/smody/src/main/java/com/woowacourse/smody/ranking/dto/RankingPeriodResponse.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/ranking/dto/RankingPeriodResponse.java
@@ -1,6 +1,8 @@
 package com.woowacourse.smody.ranking.dto;
 
+import com.woowacourse.smody.ranking.domain.RankingPeriod;
 import java.time.LocalDateTime;
+import java.util.Locale;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,4 +15,12 @@ public class RankingPeriodResponse {
     private Long rankingPeriodId;
     private LocalDateTime startDate;
     private String duration;
+
+    public RankingPeriodResponse(RankingPeriod rankingPeriod) {
+        this.rankingPeriodId = rankingPeriod.getId();
+        this.startDate = rankingPeriod.getStartDate();
+        this.duration = rankingPeriod.getDuration()
+                .name()
+                .toLowerCase();
+    }
 }

--- a/backend/smody/src/main/java/com/woowacourse/smody/ranking/repository/RankingPeriodRepository.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/ranking/repository/RankingPeriodRepository.java
@@ -1,0 +1,10 @@
+package com.woowacourse.smody.ranking.repository;
+
+import com.woowacourse.smody.ranking.domain.RankingPeriod;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RankingPeriodRepository extends JpaRepository<RankingPeriod, Long> {
+
+    List<RankingPeriod> findAllByOrderByStartDateDesc();
+}

--- a/backend/smody/src/main/java/com/woowacourse/smody/ranking/service/RankingPeriodService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/ranking/service/RankingPeriodService.java
@@ -1,12 +1,25 @@
 package com.woowacourse.smody.ranking.service;
 
+import com.woowacourse.smody.ranking.domain.RankingPeriod;
 import com.woowacourse.smody.ranking.dto.RankingPeriodResponse;
+import com.woowacourse.smody.ranking.repository.RankingPeriodRepository;
 import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class RankingPeriodService {
-    public List<RankingPeriodResponse> findAll() {
-        return null;
+
+    private final RankingPeriodRepository rankingPeriodRepository;
+
+    public List<RankingPeriodResponse> findAllLatestOrder() {
+        List<RankingPeriod> rankingPeriods = rankingPeriodRepository.findAllByOrderByStartDateDesc();
+        return rankingPeriods.stream()
+                .map(RankingPeriodResponse::new)
+                .collect(Collectors.toList());
     }
 }

--- a/backend/smody/src/main/java/com/woowacourse/smody/ranking/service/RankingPeriodService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/ranking/service/RankingPeriodService.java
@@ -1,0 +1,12 @@
+package com.woowacourse.smody.ranking.service;
+
+import com.woowacourse.smody.ranking.dto.RankingPeriodResponse;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RankingPeriodService {
+    public List<RankingPeriodResponse> findAll() {
+        return null;
+    }
+}

--- a/backend/smody/src/main/java/com/woowacourse/smody/ui/admin/controller/AdminSecurityConfig.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/ui/admin/controller/AdminSecurityConfig.java
@@ -28,7 +28,8 @@ public class AdminSecurityConfig extends VaadinWebSecurityConfigurerAdapter {
     public void configure(WebSecurity web) {
         web.ignoring().antMatchers(
                 "/challenges/**", "/cycles/**", "/members/**", "/oauth/**", "/docs/**", "/images/**",
-                "/feeds/**", "/comments/**", "/web-push/**", "/profile/**", "/h2-console/**", "/push-notifications/**"
+                "/feeds/**", "/comments/**", "/web-push/**", "/profile/**", "/h2-console/**", "/push-notifications/**",
+                "/ranking-periods/**"
         );
     }
 

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/event/ChallengePushEventListenerTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/event/ChallengePushEventListenerTest.java
@@ -16,7 +16,6 @@ import com.woowacourse.smody.push.repository.PushNotificationRepository;
 import com.woowacourse.smody.support.IntegrationTest;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,9 +37,7 @@ class ChallengePushEventListenerTest extends IntegrationTest {
 		Cycle cycle = fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝_ID, now);
 
 		// when
-		pushStrategy.handle(new CycleCreateEvent(cycle));
-
-		taskExecutor.getThreadPoolExecutor().awaitTermination(1, TimeUnit.SECONDS);
+		syncronize(() -> pushStrategy.handle(new CycleCreateEvent(cycle)));
 
 		// then
 		LocalDateTime pushTime = now
@@ -58,8 +55,8 @@ class ChallengePushEventListenerTest extends IntegrationTest {
 		);
 	}
 
-	@DisplayName("사이클을 진행해서 새로운 인증 임박 알림을 만들 때, "
-		+ "같은 사이클의 이전 인증 임박 알림이 보내지지 않았다면 삭제한다.")
+	@DisplayName("사이클에 대한 새로운 인증 임박 알림을 만들 때, "
+		+ "이전 인증 임박 알림이 보내지지 않았다면 삭제한다.")
 	@Test
 	void push_cycleProgress() throws InterruptedException {
 		// given
@@ -68,10 +65,8 @@ class ChallengePushEventListenerTest extends IntegrationTest {
 		pushStrategy.handle(new CycleCreateEvent(cycle));
 		fixture.사이클_인증(cycle.getId(), now.plusMinutes(1));
 
-		// when
-		pushStrategy.handle(new CycleProgressEvent(cycle));
-
-		taskExecutor.getThreadPoolExecutor().awaitTermination(1, TimeUnit.SECONDS);
+		// when\
+		syncronize(() -> pushStrategy.handle(new CycleProgressEvent(cycle)));
 
 		// then
 		LocalDateTime pushTime = now

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/event/CommentPushEventListenerIntegrationTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/event/CommentPushEventListenerIntegrationTest.java
@@ -18,11 +18,9 @@ import com.woowacourse.smody.push.repository.PushNotificationRepository;
 import com.woowacourse.smody.support.IntegrationTest;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 class CommentPushEventListenerIntegrationTest extends IntegrationTest {
 
@@ -43,9 +41,7 @@ class CommentPushEventListenerIntegrationTest extends IntegrationTest {
 		CommentRequest commentRequest = new CommentRequest("댓글입니다");
 
 		// when
-		commentService.create(new TokenPayload(더즈_ID), cycleDetail.getId(), commentRequest);
-
-		taskExecutor.getThreadPoolExecutor().awaitTermination(1, TimeUnit.SECONDS);
+		syncronize(() -> commentService.create(new TokenPayload(더즈_ID), cycleDetail.getId(), commentRequest));
 
 		// then
 		PushNotification pushNotification = pushNotificationRepository.findByPushStatus(PushStatus.COMPLETE).get(0);
@@ -69,9 +65,7 @@ class CommentPushEventListenerIntegrationTest extends IntegrationTest {
 		CommentRequest commentRequest = new CommentRequest("댓글입니다");
 
 		// when
-		commentService.create(new TokenPayload(조조그린_ID), cycleDetail.getId(), commentRequest);
-
-		taskExecutor.getThreadPoolExecutor().awaitTermination(1, TimeUnit.SECONDS);
+		syncronize(() -> commentService.create(new TokenPayload(조조그린_ID), cycleDetail.getId(), commentRequest));
 
 		// then
 		List<PushNotification> results = pushNotificationRepository.findByPushStatus(PushStatus.COMPLETE);

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/event/CommentPushEventListenerTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/event/CommentPushEventListenerTest.java
@@ -21,7 +21,6 @@ import com.woowacourse.smody.push.repository.PushNotificationRepository;
 import com.woowacourse.smody.support.IntegrationTest;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -52,9 +51,7 @@ class CommentPushEventListenerTest extends IntegrationTest {
 		Comment comment = fixture.댓글_등록(cycleDetail, 더즈_ID, "댓글입니다.");
 
 		// when
-		pushStrategy.handle(new CommentCreateEvent(comment));
-
-		taskExecutor.getThreadPoolExecutor().awaitTermination(1, TimeUnit.SECONDS);
+		syncronize(() -> pushStrategy.handle(new CommentCreateEvent(comment)));
 
 		// then
 		PushNotification pushNotification = pushNotificationRepository.findByPushStatus(PushStatus.COMPLETE).get(0);
@@ -79,9 +76,7 @@ class CommentPushEventListenerTest extends IntegrationTest {
 		Comment comment = fixture.댓글_등록(cycleDetail, 더즈_ID, "댓글입니다.");
 
 		// when
-		pushStrategy.handle(new CommentCreateEvent(comment));
-
-		taskExecutor.getThreadPoolExecutor().awaitTermination(1, TimeUnit.SECONDS);
+		syncronize(() -> pushStrategy.handle(new CommentCreateEvent(comment)));
 
 		// then
 		PushNotification pushNotification = pushNotificationRepository.findByPushStatus(PushStatus.COMPLETE).get(0);

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/event/SubscriptionPushEventIntegrationTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/event/SubscriptionPushEventIntegrationTest.java
@@ -4,8 +4,6 @@ import static com.woowacourse.smody.support.ResourceFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.concurrent.TimeUnit;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,9 +34,7 @@ class SubscriptionPushEventIntegrationTest extends IntegrationTest {
 			"endpoint-link", "p256dh", "auth");
 
 		// when
-		pushSubscriptionService.subscribe(tokenPayload, subscriptionRequest);
-
-		taskExecutor.getThreadPoolExecutor().awaitTermination(1, TimeUnit.SECONDS);
+		syncronize(() -> pushSubscriptionService.subscribe(tokenPayload, subscriptionRequest));
 
 		// then
 		PushNotification pushNotification = pushNotificationRepository.findAll().get(0);

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/event/SubscriptionPushEventListenerTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/event/SubscriptionPushEventListenerTest.java
@@ -4,8 +4,6 @@ import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import java.util.concurrent.TimeUnit;
-
 import com.woowacourse.smody.push.domain.PushCase;
 import com.woowacourse.smody.push.domain.PushNotification;
 import com.woowacourse.smody.push.domain.PushStatus;
@@ -32,9 +30,7 @@ public class SubscriptionPushEventListenerTest extends IntegrationTest {
 		PushSubscription pushSubscription = fixture.알림_구독(조조그린_ID, "endpoint");
 
 		// when
-		pushStrategy.handle(new PushSubscribeEvent(pushSubscription));
-
-		taskExecutor.getThreadPoolExecutor().awaitTermination(1, TimeUnit.SECONDS);
+		syncronize(() -> pushStrategy.handle(new PushSubscribeEvent(pushSubscription)));
 
 		// then
 		PushNotification pushNotification = pushNotificationRepository.findByPushStatus(PushStatus.COMPLETE).get(0);

--- a/backend/smody/src/test/java/com/woowacourse/smody/ranking/controller/RankingControllerTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/ranking/controller/RankingControllerTest.java
@@ -1,0 +1,58 @@
+package com.woowacourse.smody.ranking.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.woowacourse.smody.ranking.dto.RankingPeriodResponse;
+import com.woowacourse.smody.support.ControllerTest;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class RankingControllerTest extends ControllerTest {
+
+    @DisplayName("전체 랭킹 기간 조회")
+    @Test
+    void findAllRankingPeriods() throws Exception {
+        // given
+        List<RankingPeriodResponse> rankingPeriodResponses = List.of(
+                new RankingPeriodResponse(
+                        1L,
+                        LocalDateTime.of(2022, 7, 1, 17, 0, 0),
+                        "week"
+                ),
+                new RankingPeriodResponse(
+                        1L,
+                        LocalDateTime.of(2022, 7, 8, 17, 0, 0),
+                        "week"
+                )
+        );
+        given(rankingPeriodService.findAll()).willReturn(rankingPeriodResponses);
+
+        // when
+        ResultActions result = mockMvc.perform(get("/ranking-periods"));
+
+        // then
+        String jsonContent = objectMapper.writeValueAsString(rankingPeriodResponses);
+        result.andExpect(status().isOk())
+                .andExpect(content().json(jsonContent))
+                .andDo(document("get-all-ranking-periods", HOST_INFO,
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("[].rankingPeriodId").type(JsonFieldType.NUMBER)
+                                        .description("RankingPeriod Id"),
+                                fieldWithPath("[].startDate").type(JsonFieldType.STRING).description("시작 날짜"),
+                                fieldWithPath("[].duration").type(JsonFieldType.STRING).description("기간")
+                        )));
+    }
+}

--- a/backend/smody/src/test/java/com/woowacourse/smody/ranking/controller/RankingControllerTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/ranking/controller/RankingControllerTest.java
@@ -37,7 +37,7 @@ public class RankingControllerTest extends ControllerTest {
                         "week"
                 )
         );
-        given(rankingPeriodService.findAll()).willReturn(rankingPeriodResponses);
+        given(rankingPeriodService.findAllLatestOrder()).willReturn(rankingPeriodResponses);
 
         // when
         ResultActions result = mockMvc.perform(get("/ranking-periods"));

--- a/backend/smody/src/test/java/com/woowacourse/smody/ranking/service/RankingPeriodServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/ranking/service/RankingPeriodServiceTest.java
@@ -1,0 +1,40 @@
+package com.woowacourse.smody.ranking.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.smody.ranking.domain.Duration;
+import com.woowacourse.smody.ranking.domain.RankingPeriod;
+import com.woowacourse.smody.ranking.dto.RankingPeriodResponse;
+import com.woowacourse.smody.ranking.repository.RankingPeriodRepository;
+import com.woowacourse.smody.support.IntegrationTest;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class RankingPeriodServiceTest extends IntegrationTest {
+
+    @Autowired
+    private RankingPeriodService rankingPeriodService;
+
+    @Autowired
+    private RankingPeriodRepository rankingPeriodRepository;
+
+    @DisplayName("전체 랭킹 기간을 최신순으로 정렬하여 조회한다.")
+    @Test
+    void findAll() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        rankingPeriodRepository.save(new RankingPeriod(now.minusWeeks(2), Duration.WEEK));
+        rankingPeriodRepository.save(new RankingPeriod(now.minusWeeks(1), Duration.WEEK));
+        rankingPeriodRepository.save(new RankingPeriod(now.minusWeeks(3), Duration.WEEK));
+
+        // when
+        List<RankingPeriodResponse> rankingPeriodResponses = rankingPeriodService.findAllLatestOrder();
+
+        // then
+        assertThat(rankingPeriodResponses).map(RankingPeriodResponse::getStartDate)
+                .containsExactly(now.minusWeeks(1), now.minusWeeks(2), now.minusWeeks(3));
+    }
+}

--- a/backend/smody/src/test/java/com/woowacourse/smody/support/ControllerTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/support/ControllerTest.java
@@ -28,6 +28,8 @@ import com.woowacourse.smody.push.controller.PushSubscriptionController;
 import com.woowacourse.smody.push.service.PushNotificationService;
 import com.woowacourse.smody.push.service.PushSubscriptionService;
 import com.woowacourse.smody.push.service.WebPushService;
+import com.woowacourse.smody.ranking.controller.RankingPeriodController;
+import com.woowacourse.smody.ranking.service.RankingPeriodService;
 import com.woowacourse.smody.ui.admin.controller.AdminSecurityConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -46,7 +48,8 @@ import org.springframework.test.web.servlet.MockMvc;
         CommentController.class,
         FeedController.class,
         PushSubscriptionController.class,
-        PushNotificationController.class
+        PushNotificationController.class,
+        RankingPeriodController.class
 })
 @Import({JwtTokenProvider.class, JwtTokenExtractor.class, AdminSecurityConfig.class, SecurityTestConfig.class})
 @MockBean(JpaMetamodelMappingContext.class)
@@ -106,4 +109,7 @@ public class ControllerTest {
 
     @MockBean
     protected PushNotificationService pushNotificationService;
+
+    @MockBean
+    protected RankingPeriodService rankingPeriodService;
 }

--- a/backend/smody/src/test/java/com/woowacourse/smody/support/IntegrationTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/support/IntegrationTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.smody.support;
 import com.woowacourse.smody.image.strategy.ImageStrategy;
 import com.woowacourse.smody.push.service.WebPushService;
 import com.woowacourse.smody.support.isoloation.SmodyTestEnvironmentExtension;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,5 +24,11 @@ public class IntegrationTest {
     protected ResourceFixture fixture;
 
     @Autowired
-    protected ThreadPoolTaskExecutor taskExecutor;
+    private ThreadPoolTaskExecutor taskExecutor;
+    
+    protected void syncronize(Runnable consumer) throws InterruptedException {
+        taskExecutor.getThreadPoolExecutor().awaitTermination(1, TimeUnit.SECONDS);
+        consumer.run();
+        taskExecutor.getThreadPoolExecutor().awaitTermination(1, TimeUnit.SECONDS);
+    }
 }


### PR DESCRIPTION
#458 

## 구현한 기능
- RankingPeriod 관련 domain, repository, service, controller 클래스 구현
- RankingPeriod의 전체 조회 로직 구현
  - StartDate 기준으로 내림차순 정렬

```sql
    select
        rankingper0_.ranking_period_id as ranking_1_7_,
        rankingper0_.duration as duration2_7_,
        rankingper0_.start_date as start_da3_7_ 
    from
        ranking_period rankingper0_ 
    order by
        rankingper0_.start_date desc
```