### PR TITLE
hotfix: 카카오톡 인앱 브라우저 등 기타 브라우저의 에러 해결

### DIFF
--- a/frontend/public/pwaServiceWorker.js
+++ b/frontend/public/pwaServiceWorker.js
@@ -1,4 +1,4 @@
-const VERSION = 'v4.9';
+const VERSION = 'v4.9.1';
 const CACHE_NAME = 'smody-cache_' + VERSION;
 const IMAGE_CACHE_NAME = 'smody-image_' + VERSION;
 

--- a/frontend/src/components/NotificationMessage/useNotificationMessage.ts
+++ b/frontend/src/components/NotificationMessage/useNotificationMessage.ts
@@ -14,7 +14,7 @@ import { CLIENT_PATH } from 'constants/path';
 
 const messageChannel = new MessageChannel();
 // 우선 채널 설정 위해 서비스워커에 port2를 전달한다
-if (navigator.serviceWorker.controller) {
+if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
   navigator.serviceWorker.controller.postMessage(
     {
       type: 'INIT_PORT',


### PR DESCRIPTION

카카오톡 인앱 브라우저 등 서비스워커가 지원되지 않는 곳에서 해당 기능을 사용하지 않도록 한다