### PR TITLE
refactor: (be) 알림 api 전송 scheduler에게 위임 밎 update n+1 해결 

### DIFF
--- a/backend/smody/src/main/java/com/woowacourse/smody/push/PushScheduler.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/PushScheduler.java
@@ -1,50 +1,75 @@
 package com.woowacourse.smody.push;
 
-import com.woowacourse.smody.member.domain.Member;
-import com.woowacourse.smody.push.domain.PushNotification;
-import com.woowacourse.smody.push.domain.PushStatus;
-import com.woowacourse.smody.push.domain.PushSubscription;
-import com.woowacourse.smody.push.repository.PushNotificationRepository;
-import com.woowacourse.smody.push.service.PushSubscriptionService;
-import com.woowacourse.smody.push.service.WebPushService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
+import static java.util.stream.Collectors.*;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.stream.Collectors.groupingBy;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.woowacourse.smody.member.domain.Member;
+import com.woowacourse.smody.push.domain.PushNotification;
+import com.woowacourse.smody.push.domain.PushSubscription;
+import com.woowacourse.smody.push.service.PushNotificationService;
+import com.woowacourse.smody.push.service.PushSubscriptionService;
+import com.woowacourse.smody.push.service.WebPushService;
+
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class PushScheduler {
 
-    private final PushNotificationRepository pushNotificationRepository;
+    private final PushNotificationService pushNotificationService;
     private final PushSubscriptionService pushSubscriptionService;
     private final WebPushService webPushService;
 
     @Transactional
     public void sendPushNotifications() {
-        List<PushNotification> notifications = pushNotificationRepository.findByPushStatus(PushStatus.IN_COMPLETE);
+        List<PushNotification> notifications = pushNotificationService.searchPushable();
 
-        LocalDateTime now = LocalDateTime.now();
-        Map<Member, List<PushNotification>> notificationsByMember = groupByMemberNotifications(notifications, now);
+        Map<Member, List<PushNotification>> notificationsByMember = groupByMemberNotifications(notifications);
 
         List<Member> members = new ArrayList<>(notificationsByMember.keySet());
         Map<Member, List<PushSubscription>> subscriptionsByMember = groupByMemberSubscriptions(members);
 
         for (Member member : notificationsByMember.keySet()) {
-            sendAllNotificationsOfMember(notificationsByMember, subscriptionsByMember, member);
+            sendNotificationsToMember(notifications, notificationsByMember, subscriptionsByMember, member);
+        }
+
+        pushNotificationService.completeAll(notifications);
+    }
+
+    private void sendNotificationsToMember(List<PushNotification> notifications,
+        Map<Member, List<PushNotification>> notificationsByMember,
+        Map<Member, List<PushSubscription>> subscriptionsByMember,
+        Member member) {
+        for (PushNotification notification : notificationsByMember.get(member)) {
+            List<PushSubscription> subscriptions = subscriptionsByMember.getOrDefault(member, List.of());
+            sendNotificationsToSubscriptions(notifications, notification, subscriptions);
         }
     }
 
-    private Map<Member, List<PushNotification>> groupByMemberNotifications(List<PushNotification> notifications,
-                                                                           LocalDateTime now) {
+    private void sendNotificationsToSubscriptions(List<PushNotification> notifications, PushNotification notification,
+        List<PushSubscription> subscriptions) {
+        for (PushSubscription pushSubscription : subscriptions) {
+            boolean isValidSubscription = webPushService.sendNotification(pushSubscription, notification);
+            handleFailedPush(notifications, notification, pushSubscription, isValidSubscription);
+        }
+    }
+
+    private void handleFailedPush(List<PushNotification> notifications, PushNotification notification,
+        PushSubscription pushSubscription, boolean isValidSubscription) {
+        if (!isValidSubscription) {
+            pushSubscriptionService.delete(pushSubscription);
+            notifications.remove(notification);
+        }
+    }
+
+    private Map<Member, List<PushNotification>> groupByMemberNotifications(List<PushNotification> notifications) {
         return notifications.stream()
-                .filter(notification -> notification.isPushable(now))
                 .collect(groupingBy(PushNotification::getMember));
     }
 
@@ -52,30 +77,5 @@ public class PushScheduler {
         return pushSubscriptionService.searchByMembers(members)
                 .stream()
                 .collect(groupingBy(PushSubscription::getMember));
-    }
-
-    private void sendAllNotificationsOfMember(Map<Member, List<PushNotification>> notificationsByMember,
-                                              Map<Member, List<PushSubscription>> subscriptionsByMember,
-                                              Member member) {
-        for (PushNotification notification : notificationsByMember.get(member)) {
-            sendNotification(subscriptionsByMember, member, notification);
-            notification.completePush();
-        }
-    }
-
-    private void sendNotification(Map<Member, List<PushSubscription>> subscriptionsByMember,
-                                  Member member,
-                                  PushNotification notification) {
-        List<PushSubscription> subscriptions = subscriptionsByMember.getOrDefault(member, List.of());
-        for (PushSubscription pushSubscription : subscriptions) {
-            boolean isValidSubscription = webPushService.sendNotification(pushSubscription, notification);
-            removeInvalidSubscription(pushSubscription, isValidSubscription);
-        }
-    }
-
-    private void removeInvalidSubscription(PushSubscription pushSubscription, boolean isValidSubscription) {
-        if (!isValidSubscription) {
-            pushSubscriptionService.delete(pushSubscription);
-        }
     }
 }

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/event/CommentPushEventListener.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/event/CommentPushEventListener.java
@@ -52,7 +52,7 @@ public class CommentPushEventListener {
         return PushNotification.builder()
                 .message(commentWriter.getNickname() + "님께서 회원님의 피드에 댓글을 남겼어요!")
                 .pushTime(comment.getCreatedAt())
-                .pushStatus(PushStatus.COMPLETE)
+                .pushStatus(PushStatus.IN_COMPLETE)
                 .pushCase(PushCase.COMMENT)
                 .member(cycleDetailWriter)
                 .pathId(comment.getCycleDetail().getId())

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/event/SubscriptionPushEventListener.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/event/SubscriptionPushEventListener.java
@@ -37,7 +37,7 @@ public class SubscriptionPushEventListener {
         return PushNotification.builder()
                 .message(member.getNickname() + "님 스모디 알림이 구독되었습니다.")
                 .pushTime(LocalDateTime.now())
-                .pushStatus(PushStatus.COMPLETE)
+                .pushStatus(PushStatus.IN_COMPLETE)
                 .member(member)
                 .pushCase(PushCase.SUBSCRIPTION)
                 .build();

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/event/SubscriptionPushEventListener.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/event/SubscriptionPushEventListener.java
@@ -1,34 +1,35 @@
 package com.woowacourse.smody.push.event;
 
-import com.woowacourse.smody.member.domain.Member;
-import com.woowacourse.smody.push.domain.*;
-import com.woowacourse.smody.push.service.PushNotificationService;
-import com.woowacourse.smody.push.service.WebPushService;
-import lombok.RequiredArgsConstructor;
+import java.time.LocalDateTime;
+
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-import java.time.LocalDateTime;
+import com.woowacourse.smody.member.domain.Member;
+import com.woowacourse.smody.push.domain.PushCase;
+import com.woowacourse.smody.push.domain.PushNotification;
+import com.woowacourse.smody.push.domain.PushStatus;
+import com.woowacourse.smody.push.domain.PushSubscribeEvent;
+import com.woowacourse.smody.push.domain.PushSubscription;
+import com.woowacourse.smody.push.service.PushNotificationService;
+
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class SubscriptionPushEventListener {
 
     private final PushNotificationService pushNotificationService;
-    private final WebPushService webPushService;
 
     @Transactional
     @Async("asyncExecutor")
     @TransactionalEventListener
     public void handle(PushSubscribeEvent event) {
         PushSubscription pushSubscription = event.getPushSubscription();
-
         Member member = pushSubscription.getMember();
-        PushNotification pushNotification = pushNotificationService.register(buildNotification(member));
-
-        webPushService.sendNotification(pushSubscription, pushNotification);
+        pushNotificationService.register(buildNotification(member));
     }
 
     public PushNotification buildNotification(Object entity) {

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/repository/PushNotificationRepository.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/repository/PushNotificationRepository.java
@@ -24,4 +24,9 @@ public interface PushNotificationRepository extends JpaRepository<PushNotificati
     @Query("select pn from PushNotification pn where pn.member = :member and pn.pushStatus = :pushStatus "
             + "order by pn.pushTime desc")
     List<PushNotification> findAllLatest(@Param("member") Member member, @Param("pushStatus") PushStatus pushStatus);
+
+    @Modifying
+    @Query("update PushNotification pn set pn.pushStatus = :pushStatus where pn in :notifications")
+	void updatePushStatusIn(@Param("notifications") List<PushNotification> notifications,
+                            @Param("pushStatus")  PushStatus pushStatus);
 }

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/event/CommentPushEventListenerIntegrationTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/event/CommentPushEventListenerIntegrationTest.java
@@ -27,7 +27,7 @@ class CommentPushEventListenerIntegrationTest extends IntegrationTest {
 	private CommentService commentService;
 
 	@Autowired
-	private PushNotificationRepository pushNotificationRepository;;
+	private PushNotificationRepository pushNotificationRepository;
 
 	@DisplayName("댓글을 작성하면 알림이 저장 된다.")
 	@Test
@@ -43,10 +43,10 @@ class CommentPushEventListenerIntegrationTest extends IntegrationTest {
 		synchronize(() -> commentService.create(new TokenPayload(더즈_ID), cycleDetail.getId(), commentRequest));
 
 		// then
-		PushNotification pushNotification = pushNotificationRepository.findByPushStatus(PushStatus.COMPLETE).get(0);
+		PushNotification pushNotification = pushNotificationRepository.findAll().get(0);
 		assertAll(
 			() -> assertThat(pushNotification.getMember().getId()).isEqualTo(조조그린_ID),
-			() -> assertThat(pushNotification.getPushStatus()).isEqualTo(PushStatus.COMPLETE),
+			() -> assertThat(pushNotification.getPushStatus()).isEqualTo(PushStatus.IN_COMPLETE),
 			() -> assertThat(pushNotification.getMessage()).isEqualTo("더즈님께서 회원님의 피드에 댓글을 남겼어요!"),
 			() -> assertThat(pushNotification.getPushCase()).isEqualTo(PushCase.COMMENT),
 			() -> assertThat(pushNotification.getPathId()).isEqualTo(cycleDetail.getId())

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/event/CommentPushEventListenerTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/event/CommentPushEventListenerTest.java
@@ -41,7 +41,7 @@ class CommentPushEventListenerTest extends IntegrationTest {
 		cycleDetail = cycle.getCycleDetails().get(0);
 	}
 
-	@DisplayName("댓글을 남기면 피드 작성자에게 발송 상태의 알림이 저장 된다.")
+	@DisplayName("댓글을 남기면 피드 작성자에게 미발송 상태의 알림이 저장 된다.")
 	@Test
 	void push() throws InterruptedException {
 		// given
@@ -51,10 +51,10 @@ class CommentPushEventListenerTest extends IntegrationTest {
 		synchronize(() -> pushStrategy.handle(new CommentCreateEvent(comment)));
 
 		// then
-		PushNotification pushNotification = pushNotificationRepository.findByPushStatus(PushStatus.COMPLETE).get(0);
+		PushNotification pushNotification = pushNotificationRepository.findAll().get(0);
 		assertAll(
 			() -> assertThat(pushNotification.getMember().getId()).isEqualTo(조조그린_ID),
-			() -> assertThat(pushNotification.getPushStatus()).isEqualTo(PushStatus.COMPLETE),
+			() -> assertThat(pushNotification.getPushStatus()).isEqualTo(PushStatus.IN_COMPLETE),
 			() -> assertThat(pushNotification.getPushTime().format(FORMATTER))
 				.isEqualTo(comment.getCreatedAt().format(FORMATTER)),
 			() -> assertThat(pushNotification.getMessage()).isEqualTo("더즈님께서 회원님의 피드에 댓글을 남겼어요!"),
@@ -65,30 +65,7 @@ class CommentPushEventListenerTest extends IntegrationTest {
 		);
 	}
 
-	@DisplayName("알림을 구독했으면 댓글을 달았을 때 알림 저장에 전송까지 실행된다.")
-	@Test
-	void push_existSubscription() throws InterruptedException {
-		// given
-		fixture.알림_구독(조조그린_ID, "endpoint");
-		Comment comment = fixture.댓글_등록(cycleDetail, 더즈_ID, "댓글입니다.");
-
-		// when
-		synchronize(() -> pushStrategy.handle(new CommentCreateEvent(comment)));
-
-		// then
-		PushNotification pushNotification = pushNotificationRepository.findByPushStatus(PushStatus.COMPLETE).get(0);
-		assertAll(
-			() -> assertThat(pushNotification.getMember().getId()).isEqualTo(조조그린_ID),
-			() -> assertThat(pushNotification.getPushStatus()).isEqualTo(PushStatus.COMPLETE),
-			() -> assertThat(pushNotification.getPushTime().format(FORMATTER))
-				.isEqualTo(comment.getCreatedAt().format(FORMATTER)),
-			() -> assertThat(pushNotification.getMessage()).isEqualTo("더즈님께서 회원님의 피드에 댓글을 남겼어요!"),
-			() -> assertThat(pushNotification.getPushCase()).isEqualTo(PushCase.COMMENT),
-			() -> assertThat(pushNotification.getPathId()).isEqualTo(cycleDetail.getId())
-		);
-	}
-
-	@DisplayName("자신의 게시글에 댓글을 달면 알림이 전송, 저장되지 않는다.")
+	@DisplayName("자신의 게시글에 댓글을 달면 알림이 저장되지 않는다.")
 	@Test
 	void push_commentMyFeed() {
 		// given

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/event/CommentPushEventListenerTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/event/CommentPushEventListenerTest.java
@@ -1,5 +1,19 @@
 package com.woowacourse.smody.push.event;
 
+import static com.woowacourse.smody.support.ResourceFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
 import com.woowacourse.smody.comment.domain.Comment;
 import com.woowacourse.smody.comment.domain.CommentCreateEvent;
 import com.woowacourse.smody.cycle.domain.Cycle;
@@ -9,20 +23,6 @@ import com.woowacourse.smody.push.domain.PushNotification;
 import com.woowacourse.smody.push.domain.PushStatus;
 import com.woowacourse.smody.push.repository.PushNotificationRepository;
 import com.woowacourse.smody.support.IntegrationTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static com.woowacourse.smody.support.ResourceFixture.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 
 class CommentPushEventListenerTest extends IntegrationTest {
 
@@ -84,9 +84,7 @@ class CommentPushEventListenerTest extends IntegrationTest {
 				.isEqualTo(comment.getCreatedAt().format(FORMATTER)),
 			() -> assertThat(pushNotification.getMessage()).isEqualTo("더즈님께서 회원님의 피드에 댓글을 남겼어요!"),
 			() -> assertThat(pushNotification.getPushCase()).isEqualTo(PushCase.COMMENT),
-			() -> assertThat(pushNotification.getPathId()).isEqualTo(cycleDetail.getId()),
-			() -> verify(webPushService)
-				.sendNotification(any(), any())
+			() -> assertThat(pushNotification.getPathId()).isEqualTo(cycleDetail.getId())
 		);
 	}
 

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/event/SubscriptionPushEventIntegrationTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/event/SubscriptionPushEventIntegrationTest.java
@@ -39,7 +39,7 @@ class SubscriptionPushEventIntegrationTest extends IntegrationTest {
 		PushNotification pushNotification = pushNotificationRepository.findAll().get(0);
 		assertAll(
 			() -> assertThat(pushNotification.getMember().getId()).isEqualTo(조조그린_ID),
-			() -> assertThat(pushNotification.getPushStatus()).isEqualTo(PushStatus.COMPLETE),
+			() -> assertThat(pushNotification.getPushStatus()).isEqualTo(PushStatus.IN_COMPLETE),
 			() -> assertThat(pushNotification.getMessage()).isEqualTo("조조그린님 스모디 알림이 구독되었습니다."),
 			() -> assertThat(pushNotification.getPushCase()).isEqualTo(PushCase.SUBSCRIPTION),
 			() -> assertThat(pushNotification.getPathId()).isNull()

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/event/SubscriptionPushEventListenerTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/event/SubscriptionPushEventListenerTest.java
@@ -19,7 +19,7 @@ class SubscriptionPushEventListenerTest extends IntegrationTest {
 	@Autowired
 	private PushNotificationRepository pushNotificationRepository;
 
-	@DisplayName("알림 구독에 대한 알림을 전송한다.")
+	@DisplayName("알림 구독에 대한 알림을 저장한다")
 	@Test
 	void push() throws InterruptedException {
 		// given
@@ -29,10 +29,10 @@ class SubscriptionPushEventListenerTest extends IntegrationTest {
 		synchronize(() -> pushStrategy.handle(new PushSubscribeEvent(pushSubscription)));
 
 		// then
-		PushNotification pushNotification = pushNotificationRepository.findByPushStatus(PushStatus.COMPLETE).get(0);
+		PushNotification pushNotification = pushNotificationRepository.findAll().get(0);
 		assertAll(
 			() -> assertThat(pushNotification.getMember().getId()).isEqualTo(조조그린_ID),
-			() -> assertThat(pushNotification.getPushStatus()).isEqualTo(PushStatus.COMPLETE),
+			() -> assertThat(pushNotification.getPushStatus()).isEqualTo(PushStatus.IN_COMPLETE),
 			() -> assertThat(pushNotification.getMessage()).contains("조조그린님 스모디 알림이 구독되었습니다."),
 			() -> assertThat(pushNotification.getPushCase()).isEqualTo(PushCase.SUBSCRIPTION),
 			() -> assertThat(pushNotification.getPathId()).isNull()


### PR DESCRIPTION
close #508 

### Sheduler에게 위임
각 EventListener 클래스에서는 알림의 저장까지만 수행함

### update n+1 해결
![image](https://user-images.githubusercontent.com/78652144/194235133-5757666d-218a-498c-a383-c68e5f7e8b66.png)

