### PR TITLE
feat : (be) 챌린지 필터링 기능 구현

### DIFF
--- a/backend/smody/src/main/java/com/woowacourse/smody/challenge/domain/ChallengingRecords.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/challenge/domain/ChallengingRecords.java
@@ -5,6 +5,8 @@ import static java.util.stream.Collectors.toList;
 
 import com.woowacourse.smody.cycle.domain.Cycle;
 import com.woowacourse.smody.member.domain.Member;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -60,5 +62,9 @@ public class ChallengingRecords {
                 .sorted(Comparator.comparing(ChallengingRecord::getLatestProgressTime).reversed()
                         .thenComparing(challengingRecord -> challengingRecord.getChallenge().getId()))
                 .collect(toList());
+    }
+
+    public List<Challenge> getChallenges() {
+        return new ArrayList<>(challengingRecords.keySet());
     }
 }

--- a/backend/smody/src/main/java/com/woowacourse/smody/challenge/domain/ChallengingRecords.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/challenge/domain/ChallengingRecords.java
@@ -5,8 +5,6 @@ import static java.util.stream.Collectors.toList;
 
 import com.woowacourse.smody.cycle.domain.Cycle;
 import com.woowacourse.smody.member.domain.Member;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -64,7 +62,10 @@ public class ChallengingRecords {
                 .collect(toList());
     }
 
-    public List<Challenge> getChallenges() {
-        return new ArrayList<>(challengingRecords.keySet());
+    public List<Challenge> getChallengesOrderByChallenger() {
+        return challengingRecords.keySet()
+                .stream()
+                .sorted(Comparator.comparing(challenge -> challengingRecords.get(challenge).size()).reversed())
+                .collect(toList());
     }
 }

--- a/backend/smody/src/main/java/com/woowacourse/smody/challenge/repository/DynamicChallengeRepositoryImpl.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/challenge/repository/DynamicChallengeRepositoryImpl.java
@@ -3,10 +3,12 @@ package com.woowacourse.smody.challenge.repository;
 import static com.woowacourse.smody.challenge.domain.QChallenge.challenge;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.woowacourse.smody.challenge.domain.Challenge;
 import com.woowacourse.smody.db_support.DynamicQuery;
 import com.woowacourse.smody.db_support.PagingParams;
+import com.woowacourse.smody.db_support.SortSelection;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -25,9 +27,13 @@ public class DynamicChallengeRepositoryImpl implements DynamicChallengeRepositor
                 .and(() -> challenge.id.gt(pagingParams.getCursorId()))
                 .build();
 
+        OrderSpecifier<?>[] orderSpecifiers = SortSelection.findByParameter(pagingParams.getSort())
+                .getOrderSpecifiers();
+
         return queryFactory
                 .selectFrom(challenge)
                 .where(conditions)
+                .orderBy(orderSpecifiers)
                 .limit(pagingParams.getSize())
                 .fetch();
     }

--- a/backend/smody/src/main/java/com/woowacourse/smody/challenge/service/ChallengeApiService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/challenge/service/ChallengeApiService.java
@@ -19,6 +19,7 @@ import com.woowacourse.smody.db_support.PagingParams;
 import com.woowacourse.smody.member.domain.Member;
 import com.woowacourse.smody.member.service.MemberService;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -38,14 +39,29 @@ public class ChallengeApiService {
         return findAllWithChallengerCountByFilter(new TokenPayload(0L), searchTime, pagingParams);
     }
 
-    public List<ChallengeTabResponse> findAllWithChallengerCountByFilter(
-            TokenPayload tokenPayload, LocalDateTime searchTime, PagingParams pagingParams
-    ) {
+    public List<ChallengeTabResponse> findAllWithChallengerCountByFilter(TokenPayload tokenPayload,
+                                                                         LocalDateTime searchTime,
+                                                                         PagingParams pagingParams) {
         Member member = memberService.searchLoginMember(tokenPayload.getId());
+        if (pagingParams.getSort().equals("popular")) {
+            return getChallengeTabResponsesWhenPopular(searchTime, pagingParams, member);
+        }
         List<Challenge> challenges = challengeService.findAllByFilter(pagingParams);
         List<Cycle> cycles = cycleService.findInProgressByChallenges(searchTime, challenges);
         ChallengingRecords challengingRecords = ChallengingRecords.from(cycles);
         return getChallengeTabResponses(challenges, member, challengingRecords);
+    }
+
+    private List<ChallengeTabResponse> getChallengeTabResponsesWhenPopular(LocalDateTime searchTime,
+                                                                           PagingParams pagingParams,
+                                                                           Member member) {
+        List<Cycle> cycles = cycleService.findInProgress(searchTime);
+        ChallengingRecords challengingRecords = ChallengingRecords.from(cycles);
+        List<Challenge> challenges = challengingRecords.getChallenges().stream()
+                .sorted(Comparator.comparing(challengingRecords::countChallenger).reversed())
+                .collect(toList());
+        List<Challenge> pagedChallenges = CursorPaging.apply(challenges, null, pagingParams.getSize());
+        return getChallengeTabResponses(pagedChallenges, member, challengingRecords);
     }
 
     private List<ChallengeTabResponse> getChallengeTabResponses(List<Challenge> challenges,

--- a/backend/smody/src/main/java/com/woowacourse/smody/challenge/service/ChallengeApiService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/challenge/service/ChallengeApiService.java
@@ -57,9 +57,7 @@ public class ChallengeApiService {
                                                                            Member member) {
         List<Cycle> cycles = cycleService.findInProgress(searchTime);
         ChallengingRecords challengingRecords = ChallengingRecords.from(cycles);
-        List<Challenge> challenges = challengingRecords.getChallenges().stream()
-                .sorted(Comparator.comparing(challengingRecords::countChallenger).reversed())
-                .collect(toList());
+        List<Challenge> challenges = challengingRecords.getChallengesOrderByChallenger();
         List<Challenge> pagedChallenges = CursorPaging.apply(challenges, null, pagingParams.getSize());
         return getChallengeTabResponses(pagedChallenges, member, challengingRecords);
     }

--- a/backend/smody/src/main/java/com/woowacourse/smody/challenge/service/ChallengeService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/challenge/service/ChallengeService.java
@@ -2,9 +2,11 @@ package com.woowacourse.smody.challenge.service;
 
 import com.woowacourse.smody.challenge.domain.Challenge;
 import com.woowacourse.smody.challenge.repository.ChallengeRepository;
+import com.woowacourse.smody.cycle.domain.Cycle;
 import com.woowacourse.smody.db_support.PagingParams;
 import com.woowacourse.smody.exception.BusinessException;
 import com.woowacourse.smody.exception.ExceptionData;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/repository/CycleRepository.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/repository/CycleRepository.java
@@ -15,7 +15,10 @@ import org.springframework.data.repository.query.Param;
 
 public interface CycleRepository extends JpaRepository<Cycle, Long>, DynamicCycleRepository {
 
-    List<Cycle> findAllByStartTimeIsAfter(LocalDateTime startTime);
+    @Query("select c from Cycle c "
+            + "join fetch c.challenge "
+            + "where c.startTime >= :startTime")
+    List<Cycle> findAllByStartTimeIsAfter(@Param("startTime") LocalDateTime startTime);
 
     List<Cycle> findAllByStartTimeIsAfterAndChallengeIn(LocalDateTime startTime, List<Challenge> challenges);
 

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/repository/CycleRepository.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/repository/CycleRepository.java
@@ -17,7 +17,7 @@ public interface CycleRepository extends JpaRepository<Cycle, Long>, DynamicCycl
 
     @Query("select c from Cycle c "
             + "join fetch c.challenge "
-            + "where c.startTime >= :startTime")
+            + "where c.startTime > :startTime")
     List<Cycle> findAllByStartTimeIsAfter(@Param("startTime") LocalDateTime startTime);
 
     List<Cycle> findAllByStartTimeIsAfterAndChallengeIn(LocalDateTime startTime, List<Challenge> challenges);

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/service/CycleService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/service/CycleService.java
@@ -107,4 +107,11 @@ public class CycleService {
                 LocalDateTime.now().minusDays(Cycle.DAYS)
         );
     }
+
+    public List<Cycle> findInProgress(LocalDateTime searchTime) {
+        return cycleRepository.findAllByStartTimeIsAfter(searchTime.minusDays(Cycle.DAYS))
+                .stream()
+                .filter(cycle -> cycle.isInProgress(searchTime))
+                .collect(toList());
+    }
 }

--- a/backend/smody/src/main/java/com/woowacourse/smody/db_support/CursorPaging.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/db_support/CursorPaging.java
@@ -15,10 +15,10 @@ public class CursorPaging {
     }
 
     private static <T> int getStartIndex(List<T> list, T cursor) {
-        if (cursor != null) {
-            return list.indexOf(cursor) + 1;
+        if (cursor == null) {
+            return 0;
         }
-        return 0;
+        return list.indexOf(cursor) + 1;
     }
 
     private static int getLastIndex(Integer totalSize, Integer lastIndex) {

--- a/backend/smody/src/main/java/com/woowacourse/smody/db_support/PagingParams.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/db_support/PagingParams.java
@@ -33,6 +33,13 @@ public class PagingParams {
         this.cursorId = cursorId;
     }
 
+    public String getSort() {
+        if (this.sort == null) {
+            return "";
+        }
+        return sort;
+    }
+
     public Integer getSize() {
         if (this.size == null || this.size <= 0) {
             return 10;

--- a/backend/smody/src/main/java/com/woowacourse/smody/db_support/SortSelection.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/db_support/SortSelection.java
@@ -1,8 +1,15 @@
 package com.woowacourse.smody.db_support;
 
+import static com.woowacourse.smody.cycle.domain.QCycle.cycle;
 import static com.woowacourse.smody.cycle.domain.QCycleDetail.cycleDetail;
+import static com.woowacourse.smody.ranking.domain.QRankingPeriod.rankingPeriod;
 
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.woowacourse.smody.cycle.domain.QCycle;
+import com.woowacourse.smody.exception.BusinessException;
+import com.woowacourse.smody.exception.ExceptionData;
+import com.woowacourse.smody.ranking.domain.QRankingPeriod;
 import java.util.Arrays;
 import org.springframework.data.domain.Sort;
 
@@ -44,7 +51,10 @@ public enum SortSelection {
 
         @Override
         public OrderSpecifier<?>[] getOrderSpecifiers() {
-            return new OrderSpecifier[0];
+            return new OrderSpecifier[]{
+                    cycle.startTime.desc(),
+                    cycle.id.desc()
+            };
         }
     },
 
@@ -56,9 +66,27 @@ public enum SortSelection {
 
         @Override
         public OrderSpecifier<?>[] getOrderSpecifiers() {
-            return new OrderSpecifier[0];
+            return new OrderSpecifier[]{
+                    rankingPeriod.startDate.desc()
+            };
         }
-    };
+    },
+
+    RANDOM("random") {
+        @Override
+        public Sort getSort() {
+            throw new BusinessException(ExceptionData.NOT_FOUND_SORT);
+        }
+
+        @Override
+        public OrderSpecifier<?>[] getOrderSpecifiers() {
+            return new OrderSpecifier[]{
+                NumberExpression.random().asc()
+            };
+        }
+    }
+
+    ;
 
     private final String parameter;
 

--- a/backend/smody/src/main/java/com/woowacourse/smody/exception/ExceptionData.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/exception/ExceptionData.java
@@ -43,7 +43,8 @@ public enum ExceptionData {
 
     AUTHORIZATION_SERVER_ERROR(9001, "인가 관련 서버 내부의 오류입니다.", 500),
     IMAGE_UPLOAD_ERROR(9002, "이미지 업로드 관련 서버 내부의 오류입니다.", 500),
-    DATA_INTEGRITY_ERROR(9003, "데이터 정합성 관련 서버 내부의 오류입니다.", 500)
+    DATA_INTEGRITY_ERROR(9003, "데이터 정합성 관련 서버 내부의 오류입니다.", 500),
+    NOT_FOUND_SORT(9004, "정렬 기준을 찾을 수 없습니다.", 500)
     ;
 
     private final int code;

--- a/backend/smody/src/test/java/com/woowacourse/smody/challenge/repository/ChallengeRepositoryTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/challenge/repository/ChallengeRepositoryTest.java
@@ -1,0 +1,31 @@
+package com.woowacourse.smody.challenge.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.smody.challenge.domain.Challenge;
+import com.woowacourse.smody.db_support.PagingParams;
+import com.woowacourse.smody.support.RepositoryTest;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class ChallengeRepositoryTest extends RepositoryTest {
+
+    @Autowired
+    private ChallengeRepository challengeRepository;
+
+    @DisplayName("임의의 챌린지 데이터 2개를 조회한다.")
+    @Test
+    void findAllOrderByRandomLimit2() {
+        // given
+        PagingParams pagingParams = new PagingParams("random", 2);
+
+        // when
+        List<Challenge> actual = challengeRepository.findAllByFilter(pagingParams);
+
+        // then
+        assertThat(actual).hasSize(2);
+    }
+
+}

--- a/backend/smody/src/test/java/com/woowacourse/smody/challenge/repository/ChallengeRepositoryTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/challenge/repository/ChallengeRepositoryTest.java
@@ -27,5 +27,4 @@ class ChallengeRepositoryTest extends RepositoryTest {
         // then
         assertThat(actual).hasSize(2);
     }
-
 }

--- a/backend/smody/src/test/java/com/woowacourse/smody/challenge/service/ChallengeApiServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/challenge/service/ChallengeApiServiceTest.java
@@ -1,14 +1,22 @@
 package com.woowacourse.smody.challenge.service;
 
+import static com.woowacourse.smody.support.ResourceFixture.더즈_ID;
 import static com.woowacourse.smody.support.ResourceFixture.미라클_모닝_ID;
+import static com.woowacourse.smody.support.ResourceFixture.스모디_방문하기_ID;
+import static com.woowacourse.smody.support.ResourceFixture.알파_ID;
+import static com.woowacourse.smody.support.ResourceFixture.오늘의_운동_ID;
 import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
+import static com.woowacourse.smody.support.ResourceFixture.토닉_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.smody.auth.dto.TokenPayload;
 import com.woowacourse.smody.challenge.dto.ChallengeHistoryResponse;
+import com.woowacourse.smody.challenge.dto.ChallengeTabResponse;
+import com.woowacourse.smody.db_support.PagingParams;
 import com.woowacourse.smody.support.IntegrationTest;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,11 +35,9 @@ class ChallengeApiServiceTest extends IntegrationTest {
         fixture.사이클_생성_FIRST(조조그린_ID, 미라클_모닝_ID, LocalDateTime.now());
         fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝_ID, LocalDateTime.now());
 
-        System.out.println("#####");
         // when
         ChallengeHistoryResponse challengeHistoryResponse =
                 challengeApiService.findByMeAndChallenge(new TokenPayload(조조그린_ID), 미라클_모닝_ID);
-        System.out.println("#####");
 
         // then
         assertAll(
@@ -39,5 +45,30 @@ class ChallengeApiServiceTest extends IntegrationTest {
                 () -> assertThat(challengeHistoryResponse.getSuccessCount()).isEqualTo(1),
                 () -> assertThat(challengeHistoryResponse.getCycleDetailCount()).isEqualTo(6)
         );
+    }
+
+    @DisplayName("참가자 순으로 정렬하여 조회")
+    @Test
+    void findAllWithChallengerCountByFilter_popular() {
+        // given
+        fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝_ID, LocalDateTime.now());
+        fixture.사이클_생성_NOTHING(더즈_ID, 미라클_모닝_ID, LocalDateTime.now());
+        fixture.사이클_생성_NOTHING(토닉_ID, 미라클_모닝_ID, LocalDateTime.now());
+        fixture.사이클_생성_NOTHING(알파_ID, 미라클_모닝_ID, LocalDateTime.now());
+
+        fixture.사이클_생성_NOTHING(조조그린_ID, 오늘의_운동_ID, LocalDateTime.now());
+        fixture.사이클_생성_NOTHING(더즈_ID, 오늘의_운동_ID, LocalDateTime.now());
+        fixture.사이클_생성_NOTHING(토닉_ID, 오늘의_운동_ID, LocalDateTime.now());
+
+        fixture.사이클_생성_NOTHING(조조그린_ID, 스모디_방문하기_ID, LocalDateTime.now());
+        fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, LocalDateTime.now());
+
+        // when
+        List<ChallengeTabResponse> actual = challengeApiService.findAllWithChallengerCountByFilter(LocalDateTime.now(),
+                new PagingParams("popular", 3));
+
+        // then
+        assertThat(actual).map(ChallengeTabResponse::getChallengeName)
+                .containsExactly("미라클 모닝", "오늘의 운동", "스모디 방문하기");
     }
 }

--- a/backend/smody/src/test/java/com/woowacourse/smody/challenge/service/ChallengeApiServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/challenge/service/ChallengeApiServiceTest.java
@@ -1,8 +1,10 @@
 package com.woowacourse.smody.challenge.service;
 
+import static com.woowacourse.smody.support.ResourceFixture.JPA_공부_ID;
 import static com.woowacourse.smody.support.ResourceFixture.더즈_ID;
 import static com.woowacourse.smody.support.ResourceFixture.미라클_모닝_ID;
 import static com.woowacourse.smody.support.ResourceFixture.스모디_방문하기_ID;
+import static com.woowacourse.smody.support.ResourceFixture.알고리즘_풀기_ID;
 import static com.woowacourse.smody.support.ResourceFixture.알파_ID;
 import static com.woowacourse.smody.support.ResourceFixture.오늘의_운동_ID;
 import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
@@ -11,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.smody.auth.dto.TokenPayload;
+import com.woowacourse.smody.challenge.domain.Challenge;
 import com.woowacourse.smody.challenge.dto.ChallengeHistoryResponse;
 import com.woowacourse.smody.challenge.dto.ChallengeTabResponse;
 import com.woowacourse.smody.db_support.PagingParams;
@@ -65,7 +68,63 @@ class ChallengeApiServiceTest extends IntegrationTest {
 
         // when
         List<ChallengeTabResponse> actual = challengeApiService.findAllWithChallengerCountByFilter(LocalDateTime.now(),
-                new PagingParams("popular", 3));
+                new PagingParams("popular", 10));
+
+        // then
+        assertThat(actual).map(ChallengeTabResponse::getChallengeName)
+                .containsExactly("미라클 모닝", "오늘의 운동", "스모디 방문하기");
+    }
+
+    @DisplayName("참가자 순으로 size에 맞게 조회")
+    @Test
+    void findAllWithChallengerCountByFilter_popular_size() {
+        // given
+        fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝_ID, LocalDateTime.now());
+        fixture.사이클_생성_NOTHING(더즈_ID, 미라클_모닝_ID, LocalDateTime.now());
+        fixture.사이클_생성_NOTHING(토닉_ID, 미라클_모닝_ID, LocalDateTime.now());
+        fixture.사이클_생성_NOTHING(알파_ID, 미라클_모닝_ID, LocalDateTime.now());
+
+        fixture.사이클_생성_NOTHING(조조그린_ID, 오늘의_운동_ID, LocalDateTime.now());
+        fixture.사이클_생성_NOTHING(더즈_ID, 오늘의_운동_ID, LocalDateTime.now());
+        fixture.사이클_생성_NOTHING(토닉_ID, 오늘의_운동_ID, LocalDateTime.now());
+
+        fixture.사이클_생성_NOTHING(조조그린_ID, 스모디_방문하기_ID, LocalDateTime.now());
+        fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, LocalDateTime.now());
+
+        // when
+        List<ChallengeTabResponse> actual = challengeApiService.findAllWithChallengerCountByFilter(LocalDateTime.now(),
+                new PagingParams("popular", 2));
+
+        // then
+        assertThat(actual).map(ChallengeTabResponse::getChallengeName)
+                .containsExactly("미라클 모닝", "오늘의 운동");
+    }
+
+    @DisplayName("참가자 순으로 조회할 때 참가자가 없는 챌린지는 조회하지 않는다.")
+    @Test
+    void findAllWithChallengerCountByFilter_popular_notExistEmptyChallengers() {
+        // given
+        Challenge 미라클_모닝 = fixture.챌린지_조회(미라클_모닝_ID);
+        Challenge 오늘의_운동 = fixture.챌린지_조회(오늘의_운동_ID);
+        Challenge 스모디_방문하기 = fixture.챌린지_조회(스모디_방문하기_ID);
+        Challenge 알고리즘_풀기 = fixture.챌린지_조회(알고리즘_풀기_ID);
+        Challenge JPA_공부 = fixture.챌린지_조회(JPA_공부_ID);
+
+        fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝.getId(), LocalDateTime.now());
+        fixture.사이클_생성_NOTHING(더즈_ID, 미라클_모닝.getId(), LocalDateTime.now());
+        fixture.사이클_생성_NOTHING(토닉_ID, 미라클_모닝.getId(), LocalDateTime.now());
+        fixture.사이클_생성_NOTHING(알파_ID, 미라클_모닝.getId(), LocalDateTime.now());
+
+        fixture.사이클_생성_NOTHING(조조그린_ID, 오늘의_운동.getId(), LocalDateTime.now());
+        fixture.사이클_생성_NOTHING(더즈_ID, 오늘의_운동.getId(), LocalDateTime.now());
+        fixture.사이클_생성_NOTHING(토닉_ID, 오늘의_운동.getId(), LocalDateTime.now());
+
+        fixture.사이클_생성_NOTHING(조조그린_ID, 스모디_방문하기.getId(), LocalDateTime.now());
+        fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기.getId(), LocalDateTime.now());
+
+        // when
+        List<ChallengeTabResponse> actual = challengeApiService.findAllWithChallengerCountByFilter(LocalDateTime.now(),
+                new PagingParams("popular", 5));
 
         // then
         assertThat(actual).map(ChallengeTabResponse::getChallengeName)

--- a/backend/smody/src/test/java/com/woowacourse/smody/cycle/service/CycleServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/cycle/service/CycleServiceTest.java
@@ -157,4 +157,44 @@ class CycleServiceTest extends IntegrationTest {
             assertThat(cycles).hasSize(1);
         }
     }
+
+    @DisplayName("진행중인 사이클을 조회한다.")
+    @Test
+    void findInProgress() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝_ID, now);
+        fixture.사이클_생성_NOTHING(조조그린_ID, 스모디_방문하기_ID, now);
+        fixture.사이클_생성_NOTHING(조조그린_ID, 오늘의_운동_ID, now);
+
+        fixture.사이클_생성_NOTHING(조조그린_ID, 오늘의_운동_ID, now.minusDays(1).minusMinutes(1));
+        fixture.사이클_생성_SUCCESS(조조그린_ID, 오늘의_운동_ID, now.minusDays(3));
+
+        // when
+        List<Cycle> actual = cycleService.findInProgress(now);
+
+        // then
+        assertThat(actual).map(cycle -> cycle.getChallenge().getId())
+                .containsExactly(미라클_모닝_ID, 스모디_방문하기_ID, 오늘의_운동_ID);
+    }
+
+    @DisplayName("진행중인 사이클을 조회할 때 챌린지도 같이 조회한다.")
+    @Test
+    void findInProgressWithChallenge() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝_ID, now);
+        fixture.사이클_생성_NOTHING(조조그린_ID, 스모디_방문하기_ID, now);
+        fixture.사이클_생성_NOTHING(조조그린_ID, 오늘의_운동_ID, now);
+
+        fixture.사이클_생성_NOTHING(조조그린_ID, 오늘의_운동_ID, now.minusDays(1).minusMinutes(1));
+        fixture.사이클_생성_SUCCESS(조조그린_ID, 오늘의_운동_ID, now.minusDays(3));
+
+        // when
+        List<Cycle> actual = cycleService.findInProgress(now);
+
+        // then
+        assertThat(actual).map(cycle -> cycle.getChallenge().getName())
+                .containsExactly("미라클 모닝", "스모디 방문하기", "오늘의 운동");
+    }
 }


### PR DESCRIPTION
#556

## 챌린지 필터링 기능 구현

### `/challenges?sort=random&size=10`
- 임의의 챌린지를 조회

### `/challenges?sort=popular&size=10`
- 현재 진행중인 참가자 순으로 조회