### PR TITLE
fix : (be) 챌린지 조회할 때 `[, ]`로 검색 시 에러 해결

### DIFF
--- a/backend/smody/src/main/java/com/woowacourse/smody/config/TomcatWebCustomConfig.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/config/TomcatWebCustomConfig.java
@@ -1,0 +1,14 @@
+package com.woowacourse.smody.config;
+
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TomcatWebCustomConfig implements WebServerFactoryCustomizer<TomcatServletWebServerFactory> {
+
+    @Override
+    public void customize(TomcatServletWebServerFactory factory) {
+        factory.addConnectorCustomizers(connector -> connector.setProperty("relaxedQueryChars", "<>[\\]^`{|}"));
+    }
+}


### PR DESCRIPTION
## `/challenges?filter=[` 조회 시 400 에러 발생

<img width="474" alt="image" src="https://user-images.githubusercontent.com/59171113/195799962-14cf72b8-a259-4c9b-8e5b-a9c073fe151a.png">

```text
java.lang.IllegalArgumentException: Invalid character found in the request target [/challenges?filter=[ ]. The valid characters are defined in RFC 7230 and RFC 3986
```

### 원인
- https://dev-jwblog.tistory.com/49

스프링 부트에서 사용하는 내장 톰캣이 특정 버전 이상에서는 RFC 3986 규격을 사용합니다.
> [HTTP/1.1 사양](https://tools.ietf.org/rfc/rfc7230.txt) 에서는 URI 쿼리 문자열에 사용할 때 특정 문자가 %nn 인코딩되도록 요구합니다. 불행히도 모든 주요 브라우저를 포함한 많은 사용자 에이전트는 이 사양을 준수하지 않고 이러한 문자를 인코딩되지 않은 형태로 사용합니다. Tomcat이 이러한 요청을 거부하는 것을 방지하기 위해 이 속성을 사용하여 허용할 추가 문자를 지정할 수 있습니다. 지정하지 않으면 추가 문자가 허용되지 않습니다. 값은 다음 문자의 조합일 수 있습니다 " < > [ \ ] ^ ` { | }. . 값에 있는 다른 모든 문자는 무시됩니다.

### 해결
```java
package com.woowacourse.smody.config;

import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
import org.springframework.boot.web.server.WebServerFactoryCustomizer;
import org.springframework.context.annotation.Configuration;

@Configuration
public class TomcatWebCustomConfig implements WebServerFactoryCustomizer<TomcatServletWebServerFactory> {

    @Override
    public void customize(TomcatServletWebServerFactory factory) {
        factory.addConnectorCustomizers(connector -> connector.setProperty("relaxedQueryChars", "<>[\\]^`{|}"));
    }
}
```
