### PR TITLE
feat: (be) n대의 WAS에서 스케줄러 가동 여부 유연하게 결정 구현

### DIFF
--- a/backend/smody/src/main/java/com/woowacourse/smody/SmodyApplication.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/SmodyApplication.java
@@ -1,15 +1,15 @@
 package com.woowacourse.smody;
 
 import java.util.TimeZone;
+
 import javax.annotation.PostConstruct;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 
 @SpringBootApplication
-@EnableScheduling
 @EnableJpaAuditing
 public class SmodyApplication {
 

--- a/backend/smody/src/main/java/com/woowacourse/smody/config/WebPushSchedulerConfig.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/config/WebPushSchedulerConfig.java
@@ -1,9 +1,12 @@
-package com.woowacourse.smody.push;
+package com.woowacourse.smody.config;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
+
+import com.woowacourse.smody.push.WebPushBatch;
+import com.woowacourse.smody.push.WebPushScheduler;
 
 import lombok.RequiredArgsConstructor;
 

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/WebPushBatch.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/WebPushBatch.java
@@ -1,24 +1,26 @@
 package com.woowacourse.smody.push;
 
-import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.woowacourse.smody.member.domain.Member;
 import com.woowacourse.smody.push.domain.PushNotification;
 import com.woowacourse.smody.push.domain.PushSubscription;
 import com.woowacourse.smody.push.service.PushNotificationService;
-import com.woowacourse.smody.push.service.PushSubscriptionApiService;
 import com.woowacourse.smody.push.service.PushSubscriptionService;
 import com.woowacourse.smody.push.service.WebPushService;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
-public class PushScheduler {
+public class WebPushBatch {
 
     private final PushNotificationService pushNotificationService;
     private final PushSubscriptionService pushSubscriptionService;

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/WebPushScheduler.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/WebPushScheduler.java
@@ -1,17 +1,16 @@
 package com.woowacourse.smody.push;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
 
-@Component
+import lombok.RequiredArgsConstructor;
+
 @RequiredArgsConstructor
-public class PushSchedulerExecutor {
+public class WebPushScheduler {
 
-    private final PushScheduler pushScheduler;
+    private final WebPushBatch webPushBatch;
 
     @Scheduled(initialDelay = 5000, fixedDelayString = "${push.schedule.period}")
     public void execute() {
-        pushScheduler.sendPushNotifications();
+        webPushBatch.sendPushNotifications();
     }
 }

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/WebPushSchedulerConfig.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/WebPushSchedulerConfig.java
@@ -1,0 +1,22 @@
+package com.woowacourse.smody.push;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableScheduling
+@RequiredArgsConstructor
+public class WebPushSchedulerConfig {
+    
+    private final WebPushBatch webPushBatch;
+    
+    @Bean
+    @ConditionalOnProperty(value = "batch.schedule.enabled", havingValue = "true")
+    public WebPushScheduler webPushScheduler() {
+        return new WebPushScheduler(webPushBatch);
+    }
+}

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/WebPushBatchTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/WebPushBatchTest.java
@@ -25,10 +25,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-class PushSchedulerTest extends IntegrationTest {
+class WebPushBatchTest extends IntegrationTest {
 
     @Autowired
-    private PushScheduler pushScheduler;
+    private WebPushBatch webPushBatch;
 
     @Autowired
     private PushNotificationRepository pushNotificationRepository;
@@ -64,7 +64,7 @@ class PushSchedulerTest extends IntegrationTest {
                 .willReturn(true);
 
         // when
-        pushScheduler.sendPushNotifications();
+        webPushBatch.sendPushNotifications();
 
         // then
         List<PushNotification> result = pushNotificationRepository.findByPushStatus(PushStatus.COMPLETE);
@@ -83,7 +83,7 @@ class PushSchedulerTest extends IntegrationTest {
                 .willReturn(false);
 
         // when
-        pushScheduler.sendPushNotifications();
+        webPushBatch.sendPushNotifications();
 
         // then
         List<PushNotification> result = pushNotificationRepository.findByPushStatus(PushStatus.COMPLETE);
@@ -102,7 +102,7 @@ class PushSchedulerTest extends IntegrationTest {
                 .willReturn(false);
 
         // when
-        pushScheduler.sendPushNotifications();
+        webPushBatch.sendPushNotifications();
 
         // then
         List<PushSubscription> subscriptions = pushSubscriptionService.searchByMembers(


### PR DESCRIPTION
### 스케줄러 가동
`java -jar -Dspring.profiles.active=prod -Dbatch.schedule.enabled=true smody-0.0.1-SNAPSHOT.jar`

### 스케줄러 가동 X
`java -jar -Dspring.profiles.active=prod smody-0.0.1-SNAPSHOT.jar
`

### 구현 원리
![image](https://user-images.githubusercontent.com/78652144/195834751-24f63f9b-2fba-482f-8357-2c22c430fe86.png)

`batch.schedule.enabled=true`일 때만 스케줄러 빈이 등록되도록 구현
`batch.schedule.enabled` 값이 없으면 자동으로 스케줄러가 안돌도록 동작