### PR TITLE
fix :  (be) 회원 탈퇴 시 외래키 제약조건 에러 수정

### DIFF
--- a/backend/smody/src/main/java/com/woowacourse/smody/comment/domain/Comment.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/comment/domain/Comment.java
@@ -16,6 +16,8 @@ import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -33,6 +35,7 @@ public class Comment extends AuditingEntity {
 
     @JoinColumn(name = "member_id")
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @Column(nullable = false)

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/Cycle.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/Cycle.java
@@ -26,6 +26,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -41,6 +43,7 @@ public class Cycle {
 
     @JoinColumn(name = "member_id")
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @JoinColumn(name = "challenge_id")

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/CycleDetail.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/CycleDetail.java
@@ -20,6 +20,8 @@ import javax.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -33,6 +35,7 @@ public class CycleDetail {
 
     @JoinColumn(name = "cycle_id")
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Cycle cycle;
 
     @OneToMany(mappedBy = "cycleDetail", cascade = {CascadeType.REMOVE}, fetch = FetchType.LAZY)

--- a/backend/smody/src/main/java/com/woowacourse/smody/member/service/MemberService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/member/service/MemberService.java
@@ -1,14 +1,11 @@
 package com.woowacourse.smody.member.service;
 
-import com.woowacourse.smody.cycle.repository.CycleRepository;
 import com.woowacourse.smody.db_support.PagingParams;
 import com.woowacourse.smody.exception.BusinessException;
 import com.woowacourse.smody.exception.ExceptionData;
 import com.woowacourse.smody.image.domain.Image;
 import com.woowacourse.smody.member.domain.Member;
 import com.woowacourse.smody.member.repository.MemberRepository;
-import com.woowacourse.smody.push.repository.PushNotificationRepository;
-import com.woowacourse.smody.push.repository.PushSubscriptionRepository;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -24,9 +21,6 @@ public class MemberService {
     private static final Member NOT_LOGIN_MEMBER = new Member("email", "비회원", "없는 이미지");
 
     private final MemberRepository memberRepository;
-    private final CycleRepository cycleRepository;
-    private final PushSubscriptionRepository pushSubscriptionRepository;
-    private final PushNotificationRepository pushNotificationRepository;
 
     public Member search(Long memberId) {
         return memberRepository.findById(memberId)
@@ -64,9 +58,6 @@ public class MemberService {
     @Transactional
     public void withdraw(Long memberId) {
         Member member = search(memberId);
-        cycleRepository.deleteByMember(member);
-        pushNotificationRepository.deleteByMember(member);
-        pushSubscriptionRepository.deleteByMember(member);
         memberRepository.delete(member);
     }
 

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/WebPushBatch.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/WebPushBatch.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class WebPushBatch {
 
     private final PushNotificationService pushNotificationService;
@@ -28,6 +30,7 @@ public class WebPushBatch {
 
     @Transactional
     public void sendPushNotifications() {
+        log.info("알림 발송 시작!");
         List<PushNotification> notifications = pushNotificationService.searchPushable();
 
         Map<Member, List<PushNotification>> notificationsByMember = groupByMemberNotifications(notifications);
@@ -40,6 +43,7 @@ public class WebPushBatch {
         }
 
         pushNotificationService.completeAll(notifications);
+        log.info("알림 발송 종료!");
     }
 
     private void sendNotificationsToMember(List<PushNotification> notifications,

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/domain/PushNotification.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/domain/PushNotification.java
@@ -16,6 +16,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -29,6 +31,7 @@ public class PushNotification {
 
     @JoinColumn(name = "member_id")
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @Column(nullable = false)

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/domain/PushSubscription.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/domain/PushSubscription.java
@@ -14,6 +14,8 @@ import javax.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Table(uniqueConstraints = {
@@ -39,6 +41,7 @@ public class PushSubscription {
 
     @JoinColumn(name = "member_id")
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     public PushSubscription(String endpoint, String p256dh, String auth, Member member) {

--- a/backend/smody/src/main/java/com/woowacourse/smody/ranking/domain/RankingActivity.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/ranking/domain/RankingActivity.java
@@ -15,6 +15,8 @@ import javax.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Table(uniqueConstraints = {
@@ -35,6 +37,7 @@ public class RankingActivity {
 
     @JoinColumn(name = "member_id")
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @JoinColumn(name = "ranking_period_id")

--- a/backend/smody/src/test/java/com/woowacourse/smody/member/service/MemberApiServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/member/service/MemberApiServiceTest.java
@@ -1,0 +1,79 @@
+package com.woowacourse.smody.member.service;
+
+import static com.woowacourse.smody.support.ResourceFixture.스모디_방문하기_ID;
+import static com.woowacourse.smody.support.ResourceFixture.오늘의_운동_ID;
+import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.woowacourse.smody.auth.dto.TokenPayload;
+import com.woowacourse.smody.comment.repository.CommentRepository;
+import com.woowacourse.smody.cycle.domain.Cycle;
+import com.woowacourse.smody.cycle.repository.CycleRepository;
+import com.woowacourse.smody.exception.BusinessException;
+import com.woowacourse.smody.push.domain.PushCase;
+import com.woowacourse.smody.push.repository.PushNotificationRepository;
+import com.woowacourse.smody.push.repository.PushSubscriptionRepository;
+import com.woowacourse.smody.ranking.repository.RankingActivityRepository;
+import com.woowacourse.smody.support.IntegrationTest;
+import java.time.LocalDateTime;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class MemberApiServiceTest extends IntegrationTest {
+
+    @Autowired
+    private MemberApiService memberApiService;
+
+    @Autowired
+    private CycleRepository cycleRepository;
+
+    @Autowired
+    private PushNotificationRepository pushNotificationRepository;
+
+    @Autowired
+    private PushSubscriptionRepository pushSubscriptionRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private RankingActivityRepository rankingActivityRepository;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @DisplayName("회원 탈퇴를 한다.")
+    @Test
+    void withdraw() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        fixture.회원_조회(조조그린_ID);
+        Cycle cycle1 = fixture.사이클_생성_FIRST(조조그린_ID, 스모디_방문하기_ID, now);
+        Cycle cycle2 = fixture.사이클_생성_FIRST(조조그린_ID, 오늘의_운동_ID, now);
+        fixture.댓글_등록(cycle1.getLatestCycleDetail(), 조조그린_ID, "댓글");
+        fixture.댓글_등록(cycle2.getLatestCycleDetail(), 조조그린_ID, "댓글");
+        fixture.발송_예정_알림_생성(조조그린_ID, 1L, now, PushCase.CHALLENGE);
+        fixture.알림_구독(조조그린_ID, "endpoint");
+
+        // when
+        TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
+        memberApiService.withdraw(tokenPayload);
+
+        // then
+        assertAll(
+                () -> assertThatThrownBy(() -> memberApiService.findByMe(tokenPayload))
+                        .isInstanceOf(BusinessException.class),
+                () -> assertThat(cycleRepository.findAll()).isEmpty(),
+                () -> assertThat(em.createQuery("select cd from CycleDetail cd").getResultList()).isEmpty(),
+                () -> assertThat(pushNotificationRepository.findAll()).isEmpty(),
+                () -> assertThat(pushSubscriptionRepository.findAll()).isEmpty(),
+                () -> assertThat(commentRepository.findAll()).isEmpty(),
+                () -> assertThat(rankingActivityRepository.findAll()).isEmpty()
+        );
+    }
+}


### PR DESCRIPTION
#533

## 원인
회원 탈퇴를 할 때 외래키 제약조건으로 인해 정상적으로 동작하지 않았다.
- Cycle을 삭제할 때 `@Modify`로 하게 되면 영속성 컨텍스트를 거치지 않고 바로 쿼리가 날라가  데이터베이스에서 `CycleDetail`에 외래키 제약조건 예외가 발생한다.

## 해결
Member와 연관관계가 있는 테이블에 cascade 제약조건을 추가한다.
```java
public class Cycle {

    @JoinColumn(name = "member_id")
    @ManyToOne(fetch = FetchType.LAZY)
    @OnDelete(action = OnDeleteAction.CASCADE) // ddl에 cascade delete 제약조건 추가
    private Member member;

```

```sql
ALTER TABLE cycle
    ADD CONSTRAINT FK_CYCLE_ON_MEMBER FOREIGN KEY (member_id) REFERENCES member (member_id) ON DELETE CASCADE;
```
 다른 엔티티에도 동일하게 적용한다.

```java
// MemberService
    @Transactional
    public void withdraw(Long memberId) {
        Member member = search(memberId);
        memberRepository.delete(member); // member를 삭제하면 database의 cascade delete로 연관된 데이터를 삭제해준다.
    }
```
- Member를 삭제하면 삭제되는 데이터: Cycle, CycleDetail, Comment, PushNotification, PushSubscription, RankingActivity


