### PR TITLE
test : (be) Member, Challenge, Push 도메인 서비스 계층 테스트 추가

### DIFF
--- a/backend/smody/src/main/java/com/woowacourse/smody/exception/ExceptionData.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/exception/ExceptionData.java
@@ -28,6 +28,7 @@ public enum ExceptionData {
     NOT_FOUND_COMMENT(4005, "존재하지 않는 댓글입니다.", 404),
     NOT_FOUND_RANKING_PERIOD(4006, "존재하지 않는 랭킹 기간입니다.", 404),
     NOT_FOUND_RANKING_ACTIVITY(4007, "존재하지 않는 랭킹 활동입니다.", 404),
+    NOT_FOUND_PUSH_NOTIFICATION(4008, "알림을 찾을 수 없습니다.", 404),
 
     EMPTY_IMAGE(5001, "이미지의 바이트코드가 비었습니다.", 400),
 

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/WebPushBatch.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/WebPushBatch.java
@@ -14,7 +14,7 @@ import com.woowacourse.smody.push.domain.PushNotification;
 import com.woowacourse.smody.push.domain.PushSubscription;
 import com.woowacourse.smody.push.service.PushNotificationService;
 import com.woowacourse.smody.push.service.PushSubscriptionService;
-import com.woowacourse.smody.push.service.WebPushService;
+import com.woowacourse.smody.push.api.WebPushApi;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,7 +24,7 @@ public class WebPushBatch {
 
     private final PushNotificationService pushNotificationService;
     private final PushSubscriptionService pushSubscriptionService;
-    private final WebPushService webPushService;
+    private final WebPushApi webPushApi;
 
     @Transactional
     public void sendPushNotifications() {
@@ -55,7 +55,7 @@ public class WebPushBatch {
     private void sendNotificationsToSubscriptions(List<PushNotification> notifications, PushNotification notification,
         List<PushSubscription> subscriptions) {
         for (PushSubscription pushSubscription : subscriptions) {
-            boolean isValidSubscription = webPushService.sendNotification(pushSubscription, notification);
+            boolean isValidSubscription = webPushApi.sendNotification(pushSubscription, notification);
             handleFailedPush(notifications, notification, pushSubscription, isValidSubscription);
         }
     }

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/api/WebPushApi.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/api/WebPushApi.java
@@ -1,4 +1,4 @@
-package com.woowacourse.smody.push.service;
+package com.woowacourse.smody.push.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.smody.exception.BusinessException;
@@ -21,14 +21,14 @@ import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
-public class WebPushService {
+public class WebPushApi {
 
     private final String publicKey;
 
     private final PushService pushService;
     private final ObjectMapper objectMapper;
 
-    public WebPushService(
+    public WebPushApi(
             @Value("${vapid.public.key}") String publicKey,
             @Value("${vapid.private.key}") String privateKey) throws GeneralSecurityException {
         this.publicKey = publicKey;

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/controller/PushSubscriptionController.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/controller/PushSubscriptionController.java
@@ -7,7 +7,7 @@ import com.woowacourse.smody.push.dto.SubscriptionRequest;
 import com.woowacourse.smody.push.dto.UnSubscriptionRequest;
 import com.woowacourse.smody.push.dto.VapidPublicKeyResponse;
 import com.woowacourse.smody.push.service.PushSubscriptionApiService;
-import com.woowacourse.smody.push.service.WebPushService;
+import com.woowacourse.smody.push.api.WebPushApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,11 +22,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class PushSubscriptionController {
 
     private final PushSubscriptionApiService pushSubscriptionApiService;
-    private final WebPushService webPushService;
+    private final WebPushApi webPushApi;
 
     @GetMapping("/public-key")
     public ResponseEntity<VapidPublicKeyResponse> sendPublicKey() {
-        return ResponseEntity.ok(new VapidPublicKeyResponse(webPushService.getPublicKey()));
+        return ResponseEntity.ok(new VapidPublicKeyResponse(webPushApi.getPublicKey()));
     }
 
     @PostMapping("/subscribe")

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/event/ChallengePushEventListener.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/event/ChallengePushEventListener.java
@@ -47,7 +47,7 @@ public class ChallengePushEventListener {
     }
 
     private void deleteInCompleteNotificationIfSamePathIdPresent(Cycle cycle) {
-        pushNotificationService.searchSamePathAndStatus(cycle.getId(), PushStatus.IN_COMPLETE)
+        pushNotificationService.searchByPathAndStatusAndPushCase(cycle.getId(), PushStatus.IN_COMPLETE, PushCase.CHALLENGE)
                 .ifPresent(notification -> pushNotificationService.deleteById(notification.getId()));
     }
 

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/repository/PushNotificationRepository.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/repository/PushNotificationRepository.java
@@ -1,6 +1,7 @@
 package com.woowacourse.smody.push.repository;
 
 import com.woowacourse.smody.member.domain.Member;
+import com.woowacourse.smody.push.domain.PushCase;
 import com.woowacourse.smody.push.domain.PushNotification;
 import com.woowacourse.smody.push.domain.PushStatus;
 import java.util.List;
@@ -14,7 +15,7 @@ public interface PushNotificationRepository extends JpaRepository<PushNotificati
 
     List<PushNotification> findByPushStatus(PushStatus pushStatus);
 
-    Optional<PushNotification> findByPathIdAndPushStatus(Long pathId, PushStatus pushStatus);
+    Optional<PushNotification> findByPathIdAndPushStatusAndPushCase(Long pathId, PushStatus pushStatus, PushCase pushCase);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from PushNotification pn where pn.member = :member")

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/service/PushNotificationService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/service/PushNotificationService.java
@@ -1,6 +1,9 @@
 package com.woowacourse.smody.push.service;
 
+import com.woowacourse.smody.exception.BusinessException;
+import com.woowacourse.smody.exception.ExceptionData;
 import com.woowacourse.smody.member.domain.Member;
+import com.woowacourse.smody.push.domain.PushCase;
 import com.woowacourse.smody.push.domain.PushNotification;
 import com.woowacourse.smody.push.domain.PushStatus;
 import com.woowacourse.smody.push.repository.PushNotificationRepository;
@@ -9,6 +12,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,8 +28,8 @@ public class PushNotificationService {
         pushNotificationRepository.save(pushNotification);
     }
 
-    public Optional<PushNotification> searchSamePathAndStatus(Long pathId, PushStatus status) {
-        return pushNotificationRepository.findByPathIdAndPushStatus(pathId, status);
+    public Optional<PushNotification> searchByPathAndStatusAndPushCase(Long pathId, PushStatus status, PushCase pushCase) {
+        return pushNotificationRepository.findByPathIdAndPushStatusAndPushCase(pathId, status, pushCase);
     }
 
     public List<PushNotification> searchPushable() {
@@ -47,7 +51,11 @@ public class PushNotificationService {
 
     @Transactional
     public void deleteById(Long pushNotificationId) {
-        pushNotificationRepository.deleteById(pushNotificationId);
+        try {
+            pushNotificationRepository.deleteById(pushNotificationId);
+        } catch (EmptyResultDataAccessException e) {
+            throw new BusinessException(ExceptionData.NOT_FOUND_PUSH_NOTIFICATION);
+        }
     }
 
     @Transactional

--- a/backend/smody/src/main/java/com/woowacourse/smody/push/service/PushSubscriptionApiService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/push/service/PushSubscriptionApiService.java
@@ -36,9 +36,4 @@ public class PushSubscriptionApiService {
         memberService.search(tokenPayload.getId());
         pushSubscriptionService.deleteByEndpoint(unSubscription.getEndpoint());
     }
-
-    @Transactional
-    public void delete(PushSubscription pushSubscription) {
-        pushSubscriptionService.delete(pushSubscription);
-    }
 }

--- a/backend/smody/src/test/java/com/woowacourse/smody/challenge/service/ChallengeApiServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/challenge/service/ChallengeApiServiceTest.java
@@ -43,7 +43,7 @@ class ChallengeApiServiceTest extends IntegrationTest {
 
     private final LocalDateTime now = LocalDateTime.now();
 
-    @DisplayName("비회원이 챌린지를 도전자 수와 함께 조회 할 때 - findAllWithChallengerCountByFilter()")
+    @DisplayName("비회원이 챌린지를 도전자 수와 함께 조회 할 때")
     @Nested
     class FindAllWithChallengerCountByFilter {
 
@@ -286,7 +286,7 @@ class ChallengeApiServiceTest extends IntegrationTest {
         }
     }
 
-    @DisplayName("회원이 챌린지를 도전자 수와 함께 조회 할 때 - findAllWithChallengerCountByFilter()")
+    @DisplayName("회원이 챌린지를 도전자 수와 함께 조회 할 때")
     @Nested
     class FindAllWithChallengerCountByFilter_Login {
 
@@ -432,7 +432,7 @@ class ChallengeApiServiceTest extends IntegrationTest {
         }
     }
 
-    @DisplayName("나의 특정 챌린지에 대한 사이클 성공 횟수, 인증 횟수를 조회 할 때 - findByMeAndChallenge()")
+    @DisplayName("나의 특정 챌린지에 대한 사이클 성공 횟수, 인증 횟수를 조회 할 때")
     @Nested
     class FindByMeAndChallenge {
 
@@ -499,7 +499,7 @@ class ChallengeApiServiceTest extends IntegrationTest {
         }
     }
 
-    @DisplayName("나의 모든 챌린지를 조회할 때 - findAllByMeAndFilter()")
+    @DisplayName("나의 모든 챌린지를 조회할 때")
     @Nested
     class FindAllByMeAndFilter {
 
@@ -708,7 +708,7 @@ class ChallengeApiServiceTest extends IntegrationTest {
         }
     }
 
-    @DisplayName("하나의 챌린지를 상세 조회할 때 - findWithChallengerCount()")
+    @DisplayName("하나의 챌린지를 상세 조회할 때")
     @Nested
     class FindWithChallengerCount {
 
@@ -753,7 +753,7 @@ class ChallengeApiServiceTest extends IntegrationTest {
         }
     }
 
-    @DisplayName("챌린지의 참여자를 조회할 때 - findAllChallengers()")
+    @DisplayName("챌린지의 참여자를 조회할 때")
     @Nested
     class FindAllChallengers {
 

--- a/backend/smody/src/test/java/com/woowacourse/smody/challenge/service/ChallengeApiServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/challenge/service/ChallengeApiServiceTest.java
@@ -10,18 +10,30 @@ import static com.woowacourse.smody.support.ResourceFixture.오늘의_운동_ID;
 import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
 import static com.woowacourse.smody.support.ResourceFixture.토닉_ID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.smody.auth.dto.TokenPayload;
 import com.woowacourse.smody.challenge.domain.Challenge;
 import com.woowacourse.smody.challenge.dto.ChallengeHistoryResponse;
+import com.woowacourse.smody.challenge.dto.ChallengeOfMineResponse;
+import com.woowacourse.smody.challenge.dto.ChallengeResponse;
 import com.woowacourse.smody.challenge.dto.ChallengeTabResponse;
+import com.woowacourse.smody.challenge.dto.ChallengersResponse;
+import com.woowacourse.smody.cycle.domain.Progress;
 import com.woowacourse.smody.db_support.PagingParams;
+import com.woowacourse.smody.exception.BusinessException;
+import com.woowacourse.smody.exception.ExceptionData;
+import com.woowacourse.smody.member.domain.Member;
 import com.woowacourse.smody.support.IntegrationTest;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class ChallengeApiServiceTest extends IntegrationTest {
@@ -29,105 +41,781 @@ class ChallengeApiServiceTest extends IntegrationTest {
     @Autowired
     private ChallengeApiService challengeApiService;
 
-    @DisplayName("나의 특정 챌린지에 대한 사이클을 성공 횟수, 인증 횟수와 함께 조회")
-    @Test
-    void findByMeAndChallenge() {
-        // given
-        fixture.사이클_생성_SUCCESS(조조그린_ID, 미라클_모닝_ID, LocalDateTime.now());
-        fixture.사이클_생성_SECOND(조조그린_ID, 미라클_모닝_ID, LocalDateTime.now());
-        fixture.사이클_생성_FIRST(조조그린_ID, 미라클_모닝_ID, LocalDateTime.now());
-        fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝_ID, LocalDateTime.now());
+    private final LocalDateTime now = LocalDateTime.now();
 
-        // when
-        ChallengeHistoryResponse challengeHistoryResponse =
-                challengeApiService.findByMeAndChallenge(new TokenPayload(조조그린_ID), 미라클_모닝_ID);
+    @DisplayName("비회원이 챌린지를 도전자 수와 함께 조회 할 때 - findAllWithChallengerCountByFilter()")
+    @Nested
+    class FindAllWithChallengerCountByFilter {
 
-        // then
-        assertAll(
-                () -> assertThat(challengeHistoryResponse.getChallengeName()).isEqualTo("미라클 모닝"),
-                () -> assertThat(challengeHistoryResponse.getSuccessCount()).isEqualTo(1),
-                () -> assertThat(challengeHistoryResponse.getCycleDetailCount()).isEqualTo(6)
-        );
+        @BeforeEach
+        void setUp() {
+            // given
+            fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.NOTHING, now); // 진행 중
+            fixture.사이클_생성(더즈_ID, 미라클_모닝_ID, Progress.FIRST, now.minusDays(3L)); // 실패
+            fixture.사이클_생성(토닉_ID, 미라클_모닝_ID, Progress.SUCCESS, now.minusDays(3L)); // 성공
+            fixture.사이클_생성(더즈_ID, 스모디_방문하기_ID, Progress.FIRST, now.minusDays(1L)); // 진행 중
+            fixture.사이클_생성(조조그린_ID, 스모디_방문하기_ID, Progress.NOTHING, now); // 진행 중
+            fixture.사이클_생성(토닉_ID, 스모디_방문하기_ID, Progress.SUCCESS, now.minusDays(3L)); //성공
+        }
+
+        @DisplayName("참가자 순으로 size에 맞게 조회")
+        @Test
+        void findAllWithChallengerCountByFilter_popular_size() {
+            // given
+            fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝_ID, LocalDateTime.now());
+            fixture.사이클_생성_NOTHING(더즈_ID, 미라클_모닝_ID, LocalDateTime.now());
+            fixture.사이클_생성_NOTHING(토닉_ID, 미라클_모닝_ID, LocalDateTime.now());
+            fixture.사이클_생성_NOTHING(알파_ID, 미라클_모닝_ID, LocalDateTime.now());
+
+            fixture.사이클_생성_NOTHING(조조그린_ID, 오늘의_운동_ID, LocalDateTime.now());
+            fixture.사이클_생성_NOTHING(더즈_ID, 오늘의_운동_ID, LocalDateTime.now());
+            fixture.사이클_생성_NOTHING(토닉_ID, 오늘의_운동_ID, LocalDateTime.now());
+
+            fixture.사이클_생성_NOTHING(조조그린_ID, 스모디_방문하기_ID, LocalDateTime.now());
+            fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, LocalDateTime.now());
+
+            // when
+            List<ChallengeTabResponse> actual = challengeApiService.findAllWithChallengerCountByFilter(
+                    LocalDateTime.now(),
+                    new PagingParams("popular", 2));
+
+            // then
+            assertThat(actual).map(ChallengeTabResponse::getChallengeName)
+                    .containsExactly("미라클 모닝", "오늘의 운동");
+        }
+
+        @DisplayName("참가자 순으로 조회할 때 참가자가 없는 챌린지는 조회하지 않는다.")
+        @Test
+        void findAllWithChallengerCountByFilter_popular_notExistEmptyChallengers() {
+            // given
+            Challenge 미라클_모닝 = fixture.챌린지_조회(미라클_모닝_ID);
+            Challenge 오늘의_운동 = fixture.챌린지_조회(오늘의_운동_ID);
+            Challenge 스모디_방문하기 = fixture.챌린지_조회(스모디_방문하기_ID);
+            fixture.챌린지_조회(알고리즘_풀기_ID);
+            fixture.챌린지_조회(JPA_공부_ID);
+
+            fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝.getId(), LocalDateTime.now());
+            fixture.사이클_생성_NOTHING(더즈_ID, 미라클_모닝.getId(), LocalDateTime.now());
+            fixture.사이클_생성_NOTHING(토닉_ID, 미라클_모닝.getId(), LocalDateTime.now());
+            fixture.사이클_생성_NOTHING(알파_ID, 미라클_모닝.getId(), LocalDateTime.now());
+
+            fixture.사이클_생성_NOTHING(조조그린_ID, 오늘의_운동.getId(), LocalDateTime.now());
+            fixture.사이클_생성_NOTHING(더즈_ID, 오늘의_운동.getId(), LocalDateTime.now());
+            fixture.사이클_생성_NOTHING(토닉_ID, 오늘의_운동.getId(), LocalDateTime.now());
+
+            fixture.사이클_생성_NOTHING(조조그린_ID, 스모디_방문하기.getId(), LocalDateTime.now());
+            fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기.getId(), LocalDateTime.now());
+
+            // when
+            List<ChallengeTabResponse> actual = challengeApiService.findAllWithChallengerCountByFilter(
+                    LocalDateTime.now(),
+                    new PagingParams("popular", 5));
+
+            // then
+            assertThat(actual).map(ChallengeTabResponse::getChallengeName)
+                    .containsExactly("미라클 모닝", "오늘의 운동", "스모디 방문하기");
+        }
+
+        @DisplayName("참가자 순으로 정렬하여 조회")
+        @Test
+        void findAllWithChallengerCountByFilter_popular() {
+            // given
+            fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝_ID, LocalDateTime.now());
+            fixture.사이클_생성_NOTHING(더즈_ID, 미라클_모닝_ID, LocalDateTime.now());
+            fixture.사이클_생성_NOTHING(토닉_ID, 미라클_모닝_ID, LocalDateTime.now());
+            fixture.사이클_생성_NOTHING(알파_ID, 미라클_모닝_ID, LocalDateTime.now());
+
+            fixture.사이클_생성_NOTHING(조조그린_ID, 오늘의_운동_ID, LocalDateTime.now());
+            fixture.사이클_생성_NOTHING(더즈_ID, 오늘의_운동_ID, LocalDateTime.now());
+            fixture.사이클_생성_NOTHING(토닉_ID, 오늘의_운동_ID, LocalDateTime.now());
+
+            fixture.사이클_생성_NOTHING(조조그린_ID, 스모디_방문하기_ID, LocalDateTime.now());
+            fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, LocalDateTime.now());
+
+            // when
+            List<ChallengeTabResponse> actual = challengeApiService.findAllWithChallengerCountByFilter(
+                    LocalDateTime.now(),
+                    new PagingParams("popular", 10));
+
+            // then
+            assertThat(actual).map(ChallengeTabResponse::getChallengeName)
+                    .containsExactly("미라클 모닝", "오늘의 운동", "스모디 방문하기");
+        }
+
+        @DisplayName("조회")
+        @Test
+        void findAllWithChallengerCount_sort() {
+            // when
+            List<ChallengeTabResponse> challengeResponses = challengeApiService.findAllWithChallengerCountByFilter(
+                    now, new PagingParams(null, null, 0L, null));
+
+            // then
+            assertAll(
+                    () -> assertThat(challengeResponses).hasSize(5),
+                    () -> assertThat(challengeResponses.stream().mapToLong(ChallengeTabResponse::getChallengeId))
+                            .containsExactly(스모디_방문하기_ID, 미라클_모닝_ID, 오늘의_운동_ID, 알고리즘_풀기_ID, JPA_공부_ID),
+                    () -> assertThat(challengeResponses.stream().mapToInt(ChallengeTabResponse::getChallengerCount))
+                            .containsExactly(2, 1, 0, 0, 0)
+            );
+        }
+
+        @DisplayName("2개만 조회")
+        @Test
+        void findAllWithChallengerCount_pageFullSize() {
+            // when
+            List<ChallengeTabResponse> challengeResponses = challengeApiService.findAllWithChallengerCountByFilter(now,
+                    new PagingParams(null, 2, 0L, null));
+
+            // then
+            assertAll(
+                    () -> assertThat(challengeResponses).hasSize(2),
+                    () -> assertThat(challengeResponses.stream().map(ChallengeTabResponse::getChallengeId))
+                            .containsExactly(스모디_방문하기_ID, 미라클_모닝_ID),
+                    () -> assertThat(challengeResponses.stream().mapToInt(ChallengeTabResponse::getChallengerCount))
+                            .containsExactly(2, 1)
+            );
+        }
+
+        @DisplayName("커서 기준 2개만 조회")
+        @Test
+        void findAllWithChallengerCount_pagePartialSize() {
+            // when
+            List<ChallengeTabResponse> challengeResponses = challengeApiService.findAllWithChallengerCountByFilter(
+                    now, new PagingParams(null, 2, 미라클_모닝_ID, null));
+
+            // then
+            assertAll(
+                    () -> assertThat(challengeResponses).hasSize(2),
+                    () -> assertThat(challengeResponses.stream().mapToLong(ChallengeTabResponse::getChallengeId))
+                            .containsExactly(오늘의_운동_ID, 알고리즘_풀기_ID),
+                    () -> assertThat(challengeResponses.stream().mapToInt(ChallengeTabResponse::getChallengerCount))
+                            .containsExactly(0, 0)
+            );
+        }
+
+        @DisplayName("데이터의 마지막이 커서이면서 3개 조회")
+        @Test
+        void findAllWithChallengerCount_pageOverMaxPage() {
+            // when
+            List<ChallengeTabResponse> challengeResponses = challengeApiService.findAllWithChallengerCountByFilter(
+                    now, new PagingParams(null, 3, JPA_공부_ID, null));
+
+            // then
+            assertThat(challengeResponses).isEmpty();
+        }
+
+        @DisplayName("이름 기준으로 검색하는 경우")
+        @Test
+        void searchByName_unAuthorized() {
+            //given
+            fixture.사이클_생성_NOTHING(알파_ID, 알고리즘_풀기_ID, now);
+            fixture.사이클_생성_NOTHING(토닉_ID, 스모디_방문하기_ID, now);
+            fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, now);
+
+            // when
+            List<ChallengeTabResponse> challengeTabResponse = challengeApiService.findAllWithChallengerCountByFilter(
+                    now, new PagingParams(null, null, 0L, "기"));
+
+            // then
+            assertAll(
+                    () -> assertThat(challengeTabResponse).hasSize(2),
+                    () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getChallengeId))
+                            .containsExactly(스모디_방문하기_ID, 알고리즘_풀기_ID),
+                    () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getChallengerCount))
+                            .containsExactly(3, 1),
+                    () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getIsInProgress))
+                            .containsExactly(false, false)
+            );
+        }
+
+        @DisplayName("이름 기준으로 검색 후 페이지네이션")
+        @Test
+        void searchByName_unAuthorizedCursorPaging() {
+            //given
+            fixture.사이클_생성_NOTHING(알파_ID, 알고리즘_풀기_ID, now);
+            fixture.사이클_생성_NOTHING(토닉_ID, 스모디_방문하기_ID, now);
+            fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, now);
+
+            // when
+            List<ChallengeTabResponse> challengeTabResponse = challengeApiService.findAllWithChallengerCountByFilter(
+                    now, new PagingParams(null, null, 스모디_방문하기_ID, "기"));
+
+            // then
+            assertAll(
+                    () -> assertThat(challengeTabResponse).hasSize(1),
+                    () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getChallengeId))
+                            .containsExactly(알고리즘_풀기_ID),
+                    () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getChallengerCount))
+                            .containsExactly(1),
+                    () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getIsInProgress))
+                            .containsExactly(false)
+            );
+        }
+
+        @DisplayName("이름 기준으로 검색하고 마지막 커서로 페이지네이션")
+        @Test
+        void searchByName_unAuthorizedLastCursor() {
+            //given
+            fixture.사이클_생성_NOTHING(알파_ID, 알고리즘_풀기_ID, now);
+            fixture.사이클_생성_NOTHING(토닉_ID, 스모디_방문하기_ID, now);
+            fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, now);
+
+            // when
+            List<ChallengeTabResponse> challengeTabResponse = challengeApiService.findAllWithChallengerCountByFilter(
+                    now, new PagingParams(null, null, 알고리즘_풀기_ID, "기"));
+
+            // then
+            assertThat(challengeTabResponse).isEmpty();
+        }
+
+        @DisplayName("빈 이름 혹은 공백 문자로 검색하는 경우")
+        @ParameterizedTest
+        @ValueSource(strings = {" ", ""})
+        void searchByName_unAuthorizedWithNoName(String invalidSearchingName) {
+            //given
+            fixture.사이클_생성_NOTHING(알파_ID, 알고리즘_풀기_ID, now);
+            fixture.사이클_생성_NOTHING(토닉_ID, 스모디_방문하기_ID, now);
+            fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, now);
+
+            // when then
+            assertThatThrownBy(() -> challengeApiService.findAllWithChallengerCountByFilter(
+                    now, new PagingParams(null, null, 0L, invalidSearchingName)))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("exceptionData")
+                    .isEqualTo(ExceptionData.INVALID_SEARCH_NAME);
+        }
     }
 
-    @DisplayName("참가자 순으로 정렬하여 조회")
-    @Test
-    void findAllWithChallengerCountByFilter_popular() {
-        // given
-        fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝_ID, LocalDateTime.now());
-        fixture.사이클_생성_NOTHING(더즈_ID, 미라클_모닝_ID, LocalDateTime.now());
-        fixture.사이클_생성_NOTHING(토닉_ID, 미라클_모닝_ID, LocalDateTime.now());
-        fixture.사이클_생성_NOTHING(알파_ID, 미라클_모닝_ID, LocalDateTime.now());
+    @DisplayName("회원이 챌린지를 도전자 수와 함께 조회 할 때 - findAllWithChallengerCountByFilter()")
+    @Nested
+    class FindAllWithChallengerCountByFilter_Login {
 
-        fixture.사이클_생성_NOTHING(조조그린_ID, 오늘의_운동_ID, LocalDateTime.now());
-        fixture.사이클_생성_NOTHING(더즈_ID, 오늘의_운동_ID, LocalDateTime.now());
-        fixture.사이클_생성_NOTHING(토닉_ID, 오늘의_운동_ID, LocalDateTime.now());
+        @BeforeEach
+        void setUp() {
+            // given
+            fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.NOTHING, now); // 진행 중
+            fixture.사이클_생성(더즈_ID, 미라클_모닝_ID, Progress.FIRST, now.minusDays(3L)); // 실패
+            fixture.사이클_생성(토닉_ID, 미라클_모닝_ID, Progress.SUCCESS, now.minusDays(3L)); // 성공
+            fixture.사이클_생성(더즈_ID, 스모디_방문하기_ID, Progress.FIRST, now.minusDays(1L)); // 진행 중
+            fixture.사이클_생성(조조그린_ID, 스모디_방문하기_ID, Progress.NOTHING, now); // 진행 중
+            fixture.사이클_생성(토닉_ID, 스모디_방문하기_ID, Progress.SUCCESS, now.minusDays(3L)); //성공
+        }
 
-        fixture.사이클_생성_NOTHING(조조그린_ID, 스모디_방문하기_ID, LocalDateTime.now());
-        fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, LocalDateTime.now());
+        @DisplayName("조회")
+        @Test
+        void findAllWithChallengerCount_sortAuth() {
+            // when
+            TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
+            List<ChallengeTabResponse> challengeResponses = challengeApiService.findAllWithChallengerCountByFilter(
+                    tokenPayload, now, new PagingParams(null, null, 0L, null));
 
-        // when
-        List<ChallengeTabResponse> actual = challengeApiService.findAllWithChallengerCountByFilter(LocalDateTime.now(),
-                new PagingParams("popular", 10));
+            // then
+            assertAll(
+                    () -> assertThat(challengeResponses).hasSize(5),
+                    () -> assertThat(challengeResponses.stream().mapToLong(ChallengeTabResponse::getChallengeId))
+                            .containsExactly(스모디_방문하기_ID, 미라클_모닝_ID, 오늘의_운동_ID, 알고리즘_풀기_ID, JPA_공부_ID),
+                    () -> assertThat(challengeResponses.stream().map(ChallengeTabResponse::getIsInProgress))
+                            .containsExactly(true, true, false, false, false)
+            );
+        }
 
-        // then
-        assertThat(actual).map(ChallengeTabResponse::getChallengeName)
-                .containsExactly("미라클 모닝", "오늘의 운동", "스모디 방문하기");
+        @DisplayName("2개 조회")
+        @Test
+        void findAllWithChallengerCount_pageFullSizeAuth() {
+            // when
+            TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
+            List<ChallengeTabResponse> challengeResponses = challengeApiService.findAllWithChallengerCountByFilter(
+                    tokenPayload, now, new PagingParams(null, 2, 0L, null));
+
+            // then
+            assertAll(
+                    () -> assertThat(challengeResponses).hasSize(2),
+                    () -> assertThat(challengeResponses.stream().map(ChallengeTabResponse::getChallengeId))
+                            .containsExactly(스모디_방문하기_ID, 미라클_모닝_ID),
+                    () -> assertThat(challengeResponses.stream().mapToInt(ChallengeTabResponse::getChallengerCount))
+                            .containsExactly(2, 1),
+                    () -> assertThat(challengeResponses.stream().map(ChallengeTabResponse::getIsInProgress))
+                            .containsExactly(true, true)
+            );
+        }
+
+        @DisplayName("커서를 기준으로 2개를 조회")
+        @Test
+        void findAllWithChallengerCount_pagePartialSizeAuth() {
+            // when
+            TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
+            List<ChallengeTabResponse> challengeResponses = challengeApiService.findAllWithChallengerCountByFilter(
+                    tokenPayload, now, new PagingParams(null, 2, 미라클_모닝_ID, null));
+
+            // then
+            assertAll(
+                    () -> assertThat(challengeResponses).hasSize(2),
+                    () -> assertThat(challengeResponses.stream().mapToInt(ChallengeTabResponse::getChallengerCount))
+                            .containsExactly(0, 0),
+                    () -> assertThat(challengeResponses.stream().mapToLong(ChallengeTabResponse::getChallengeId))
+                            .containsExactly(오늘의_운동_ID, 알고리즘_풀기_ID),
+                    () -> assertThat(challengeResponses.stream().map(ChallengeTabResponse::getIsInProgress))
+                            .containsExactly(false, false)
+            );
+        }
+
+        @DisplayName("데이터의 마지막이 커서이면서 3개 조회")
+        @Test
+        void findAllWithChallengerCount_pageOverMaxPageAuth() {
+            // when
+            TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
+            List<ChallengeTabResponse> challengeResponses = challengeApiService.findAllWithChallengerCountByFilter(
+                    tokenPayload, now, new PagingParams(null, 3, JPA_공부_ID, null));
+
+            // then
+            assertThat(challengeResponses).isEmpty();
+        }
+
+        @DisplayName("이름 기준으로 검색 후 페이지네이션")
+        @Test
+        void searchByName_authorizedCursorPaging() {
+            //given
+            fixture.사이클_생성_NOTHING(알파_ID, 알고리즘_풀기_ID, now);
+            fixture.사이클_생성_NOTHING(토닉_ID, 스모디_방문하기_ID, now);
+            fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, now);
+            TokenPayload tokenPayload = new TokenPayload(알파_ID);
+
+            // when
+            List<ChallengeTabResponse> challengeTabResponse = challengeApiService.findAllWithChallengerCountByFilter(
+                    tokenPayload, now, new PagingParams(null, null, 스모디_방문하기_ID, "기"));
+
+            // then
+            assertAll(
+                    () -> assertThat(challengeTabResponse).hasSize(1),
+                    () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getChallengeId))
+                            .containsExactly(알고리즘_풀기_ID),
+                    () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getChallengerCount))
+                            .containsExactly(1),
+                    () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getIsInProgress))
+                            .containsExactly(true)
+            );
+        }
+
+        @DisplayName("이름 기준으로 검색하고 마지막 커서로 페이지네이션")
+        @Test
+        void searchByName_authorizedLastCursor() {
+            //given
+            fixture.사이클_생성_NOTHING(알파_ID, 알고리즘_풀기_ID, now);
+            fixture.사이클_생성_NOTHING(토닉_ID, 스모디_방문하기_ID, now);
+            fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, now);
+            TokenPayload tokenPayload = new TokenPayload(알파_ID);
+
+            // when
+            List<ChallengeTabResponse> challengeTabResponse = challengeApiService.findAllWithChallengerCountByFilter(
+                    tokenPayload, now, new PagingParams(null, null, 알고리즘_풀기_ID, "기"));
+
+            // then
+            assertThat(challengeTabResponse).isEmpty();
+        }
+
+        @DisplayName("빈 이름 혹은 공백 문자로 검색하는 경우")
+        @ParameterizedTest
+        @ValueSource(strings = {" ", ""})
+        void searchByName_authorizedWithNoName(String invalidSearchingName) {
+            //given
+            fixture.사이클_생성_NOTHING(알파_ID, 알고리즘_풀기_ID, now);
+            fixture.사이클_생성_NOTHING(토닉_ID, 스모디_방문하기_ID, now);
+            fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, now);
+            TokenPayload tokenPayload = new TokenPayload(알파_ID);
+
+            // when then
+            assertThatThrownBy(() -> challengeApiService.findAllWithChallengerCountByFilter(
+                    tokenPayload, now, new PagingParams(null, null, 0L, invalidSearchingName)))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("exceptionData")
+                    .isEqualTo(ExceptionData.INVALID_SEARCH_NAME);
+        }
     }
 
-    @DisplayName("참가자 순으로 size에 맞게 조회")
-    @Test
-    void findAllWithChallengerCountByFilter_popular_size() {
-        // given
-        fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝_ID, LocalDateTime.now());
-        fixture.사이클_생성_NOTHING(더즈_ID, 미라클_모닝_ID, LocalDateTime.now());
-        fixture.사이클_생성_NOTHING(토닉_ID, 미라클_모닝_ID, LocalDateTime.now());
-        fixture.사이클_생성_NOTHING(알파_ID, 미라클_모닝_ID, LocalDateTime.now());
+    @DisplayName("나의 특정 챌린지에 대한 사이클 성공 횟수, 인증 횟수를 조회 할 때 - findByMeAndChallenge()")
+    @Nested
+    class FindByMeAndChallenge {
 
-        fixture.사이클_생성_NOTHING(조조그린_ID, 오늘의_운동_ID, LocalDateTime.now());
-        fixture.사이클_생성_NOTHING(더즈_ID, 오늘의_운동_ID, LocalDateTime.now());
-        fixture.사이클_생성_NOTHING(토닉_ID, 오늘의_운동_ID, LocalDateTime.now());
+        @DisplayName("조회")
+        @Test
+        void findByMeAndChallenge() {
+            // given
+            fixture.사이클_생성_SUCCESS(조조그린_ID, 미라클_모닝_ID, LocalDateTime.now());
+            fixture.사이클_생성_SECOND(조조그린_ID, 미라클_모닝_ID, LocalDateTime.now());
+            fixture.사이클_생성_FIRST(조조그린_ID, 미라클_모닝_ID, LocalDateTime.now());
+            fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝_ID, LocalDateTime.now());
 
-        fixture.사이클_생성_NOTHING(조조그린_ID, 스모디_방문하기_ID, LocalDateTime.now());
-        fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, LocalDateTime.now());
+            // when
+            ChallengeHistoryResponse challengeHistoryResponse =
+                    challengeApiService.findByMeAndChallenge(new TokenPayload(조조그린_ID), 미라클_모닝_ID);
 
-        // when
-        List<ChallengeTabResponse> actual = challengeApiService.findAllWithChallengerCountByFilter(LocalDateTime.now(),
-                new PagingParams("popular", 2));
+            // then
+            assertAll(
+                    () -> assertThat(challengeHistoryResponse.getChallengeName()).isEqualTo("미라클 모닝"),
+                    () -> assertThat(challengeHistoryResponse.getSuccessCount()).isEqualTo(1),
+                    () -> assertThat(challengeHistoryResponse.getCycleDetailCount()).isEqualTo(6)
+            );
+        }
 
-        // then
-        assertThat(actual).map(ChallengeTabResponse::getChallengeName)
-                .containsExactly("미라클 모닝", "오늘의 운동");
+        @DisplayName("회원이 참가한 챌린지 하나를 조회하는 경우")
+        @Test
+        void findOneWithMine() {
+            //given
+            fixture.사이클_생성_FIRST(알파_ID, 알고리즘_풀기_ID, now);
+            fixture.사이클_생성_SUCCESS(알파_ID, 알고리즘_풀기_ID, now.minusDays(3L));
+            fixture.사이클_생성_SUCCESS(알파_ID, 알고리즘_풀기_ID, now.minusDays(6L));
+            fixture.사이클_생성_SECOND(알파_ID, 알고리즘_풀기_ID, now.minusDays(9L));
+
+            TokenPayload tokenPayload = new TokenPayload(알파_ID);
+
+            // when
+            ChallengeHistoryResponse challengeHistoryResponse = challengeApiService.findByMeAndChallenge(
+                    tokenPayload, 알고리즘_풀기_ID);
+
+            // then
+            assertAll(
+                    () -> assertThat(challengeHistoryResponse.getChallengeName()).isEqualTo("알고리즘 풀기"),
+                    () -> assertThat(challengeHistoryResponse.getSuccessCount()).isEqualTo(2),
+                    () -> assertThat(challengeHistoryResponse.getCycleDetailCount()).isEqualTo(9)
+            );
+        }
+
+        @DisplayName("회원이 참가하지 않은 챌린지를 조회하는 경우 예외를 던진다.")
+        @Test
+        void findOneWithMine_notParticipate() {
+            //given
+            fixture.사이클_생성_NOTHING(알파_ID, 알고리즘_풀기_ID, now);
+            fixture.사이클_생성_SUCCESS(알파_ID, 알고리즘_풀기_ID, now.minusDays(3L));
+            fixture.사이클_생성_SUCCESS(알파_ID, 알고리즘_풀기_ID, now.minusDays(6L));
+            fixture.사이클_생성_SECOND(알파_ID, 알고리즘_풀기_ID, now.minusDays(9L));
+
+            TokenPayload tokenPayload = new TokenPayload(알파_ID);
+
+            // when, then
+            assertThatThrownBy(() -> challengeApiService.findByMeAndChallenge(tokenPayload, 오늘의_운동_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("ExceptionData")
+                    .isEqualTo(ExceptionData.DATA_INTEGRITY_ERROR);
+        }
     }
 
-    @DisplayName("참가자 순으로 조회할 때 참가자가 없는 챌린지는 조회하지 않는다.")
-    @Test
-    void findAllWithChallengerCountByFilter_popular_notExistEmptyChallengers() {
-        // given
-        Challenge 미라클_모닝 = fixture.챌린지_조회(미라클_모닝_ID);
-        Challenge 오늘의_운동 = fixture.챌린지_조회(오늘의_운동_ID);
-        Challenge 스모디_방문하기 = fixture.챌린지_조회(스모디_방문하기_ID);
-        Challenge 알고리즘_풀기 = fixture.챌린지_조회(알고리즘_풀기_ID);
-        Challenge JPA_공부 = fixture.챌린지_조회(JPA_공부_ID);
+    @DisplayName("나의 모든 챌린지를 조회할 때 - findAllByMeAndFilter()")
+    @Nested
+    class FindAllByMeAndFilter {
 
-        fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝.getId(), LocalDateTime.now());
-        fixture.사이클_생성_NOTHING(더즈_ID, 미라클_모닝.getId(), LocalDateTime.now());
-        fixture.사이클_생성_NOTHING(토닉_ID, 미라클_모닝.getId(), LocalDateTime.now());
-        fixture.사이클_생성_NOTHING(알파_ID, 미라클_모닝.getId(), LocalDateTime.now());
+        private TokenPayload tokenPayload;
 
-        fixture.사이클_생성_NOTHING(조조그린_ID, 오늘의_운동.getId(), LocalDateTime.now());
-        fixture.사이클_생성_NOTHING(더즈_ID, 오늘의_운동.getId(), LocalDateTime.now());
-        fixture.사이클_생성_NOTHING(토닉_ID, 오늘의_운동.getId(), LocalDateTime.now());
+        @BeforeEach
+        void setUp() {
+            tokenPayload = new TokenPayload(조조그린_ID);
 
-        fixture.사이클_생성_NOTHING(조조그린_ID, 스모디_방문하기.getId(), LocalDateTime.now());
-        fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기.getId(), LocalDateTime.now());
+            fixture.사이클_생성(조조그린_ID, 스모디_방문하기_ID, Progress.NOTHING, now);
+            fixture.사이클_생성(조조그린_ID, 스모디_방문하기_ID, Progress.FIRST, now.minusDays(3L));
 
-        // when
-        List<ChallengeTabResponse> actual = challengeApiService.findAllWithChallengerCountByFilter(LocalDateTime.now(),
-                new PagingParams("popular", 5));
+            fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.NOTHING, now.minusSeconds(1L));
+            fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.FIRST, now.minusDays(1L));
+            fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.SUCCESS, now.minusDays(3L));
+            fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.SUCCESS, now.minusDays(6L));
 
-        // then
-        assertThat(actual).map(ChallengeTabResponse::getChallengeName)
-                .containsExactly("미라클 모닝", "오늘의 운동", "스모디 방문하기");
+            fixture.사이클_생성(조조그린_ID, 오늘의_운동_ID, Progress.SUCCESS, now.minusDays(9L));
+
+            fixture.사이클_생성(조조그린_ID, JPA_공부_ID, Progress.SUCCESS, now.minusDays(20L));
+            fixture.사이클_생성(조조그린_ID, JPA_공부_ID, Progress.SUCCESS, now.minusDays(23L));
+            fixture.사이클_생성(조조그린_ID, JPA_공부_ID, Progress.SUCCESS, now.minusDays(26L));
+
+            fixture.사이클_생성(조조그린_ID, 알고리즘_풀기_ID, Progress.SUCCESS, now.minusDays(30L));
+        }
+
+        @DisplayName("조회")
+        @Test
+        void searchOfMine() {
+            // when
+            List<ChallengeOfMineResponse> responses = challengeApiService.findAllByMeAndFilter(
+                    tokenPayload, new PagingParams(null, null, 0L, null));
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).hasSize(5),
+                    () -> assertThat(responses)
+                            .map(ChallengeOfMineResponse::getSuccessCount)
+                            .containsExactly(0, 2, 1, 3, 1),
+                    () -> assertThat(responses)
+                            .map(ChallengeOfMineResponse::getChallengeId)
+                            .containsExactly(스모디_방문하기_ID, 미라클_모닝_ID, 오늘의_운동_ID, JPA_공부_ID, 알고리즘_풀기_ID)
+            );
+        }
+
+        @DisplayName("0페이지의 3개만 조회")
+        @Test
+        void searchOfMine_pageFullSize() {
+            // when
+            List<ChallengeOfMineResponse> responses = challengeApiService.findAllByMeAndFilter(
+                    tokenPayload, new PagingParams(null, 3, 0L, null));
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).hasSize(3),
+                    () -> assertThat(responses)
+                            .map(ChallengeOfMineResponse::getSuccessCount)
+                            .containsExactly(0, 2, 1),
+                    () -> assertThat(responses)
+                            .map(ChallengeOfMineResponse::getChallengeId)
+                            .containsExactly(스모디_방문하기_ID, 미라클_모닝_ID, 오늘의_운동_ID)
+            );
+        }
+
+        @DisplayName("1페이지의 2개만 조회")
+        @Test
+        void searchOfMine_pagePartialSize() {
+            // when
+            List<ChallengeOfMineResponse> responses = challengeApiService.findAllByMeAndFilter(
+                    tokenPayload, new PagingParams(null, 2, 미라클_모닝_ID, null));
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).hasSize(2),
+                    () -> assertThat(responses)
+                            .map(ChallengeOfMineResponse::getSuccessCount)
+                            .containsExactly(1, 3),
+                    () -> assertThat(responses)
+                            .map(ChallengeOfMineResponse::getChallengeId)
+                            .containsExactly(오늘의_운동_ID, JPA_공부_ID)
+            );
+        }
+
+        @DisplayName("없는 페이지로 조회")
+        @Test
+        void searchOfMine_pageOverMaxPage() {
+            // when
+            List<ChallengeOfMineResponse> responses = challengeApiService.findAllByMeAndFilter(
+                    tokenPayload, new PagingParams(null, 3, 알고리즘_풀기_ID, null));
+
+            // then
+            assertThat(responses).isEmpty();
+        }
+
+        @DisplayName("성공한 챌린지들만 조회")
+        @Test
+        void searchSuccessOfMine() {
+            // when
+            List<ChallengeOfMineResponse> responses = challengeApiService.findAllByMeAndFilter(
+                    tokenPayload, new PagingParams(null, null, 0L, "success"));
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).hasSize(4),
+                    () -> assertThat(responses)
+                            .map(ChallengeOfMineResponse::getSuccessCount)
+                            .containsExactly(2, 1, 3, 1),
+                    () -> assertThat(responses)
+                            .map(ChallengeOfMineResponse::getChallengeId)
+                            .containsExactly(미라클_모닝_ID, 오늘의_운동_ID, JPA_공부_ID, 알고리즘_풀기_ID)
+            );
+        }
+
+        @DisplayName("내가 성공한 챌린지들의 0페이지의 3개만 조회")
+        @Test
+        void searchSuccessOfMine_pageFullSize() {
+            // when
+            List<ChallengeOfMineResponse> responses = challengeApiService.findAllByMeAndFilter(
+                    tokenPayload, new PagingParams(null, 3, 0L, "success"));
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).hasSize(3),
+                    () -> assertThat(responses)
+                            .map(ChallengeOfMineResponse::getSuccessCount)
+                            .containsExactly(2, 1, 3),
+                    () -> assertThat(responses)
+                            .map(ChallengeOfMineResponse::getChallengeId)
+                            .containsExactly(미라클_모닝_ID, 오늘의_운동_ID, JPA_공부_ID)
+            );
+        }
+
+        @DisplayName("내가 성공한 챌린지들의 1페이지의 2개만 조회")
+        @Test
+        void searchSuccessOfMine_pagePartialSize() {
+            // when
+            List<ChallengeOfMineResponse> responses = challengeApiService.findAllByMeAndFilter(
+                    tokenPayload, new PagingParams(null, 2, 오늘의_운동_ID, "success"));
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).hasSize(2),
+                    () -> assertThat(responses)
+                            .map(ChallengeOfMineResponse::getSuccessCount)
+                            .containsExactly(3, 1),
+                    () -> assertThat(responses)
+                            .map(ChallengeOfMineResponse::getChallengeId)
+                            .containsExactly(JPA_공부_ID, 알고리즘_풀기_ID)
+            );
+        }
+
+        @DisplayName("내가 성공한 챌린지들의 없는 페이지로 조회")
+        @Test
+        void searchSuccessOfMine_pageOverMaxPage() {
+            // when
+            List<ChallengeOfMineResponse> responses = challengeApiService.findAllByMeAndFilter(
+                    tokenPayload, new PagingParams(null, 3, 알고리즘_풀기_ID, "success"));
+
+            // then
+            assertThat(responses).isEmpty();
+        }
+
+        @DisplayName("같은 인증 시간이라면 id순으로 정렬")
+        @Test
+        void searchOfMine_sameTime() {
+            // given
+            TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
+
+            // when
+            List<ChallengeOfMineResponse> responses = challengeApiService.findAllByMeAndFilter(
+                    tokenPayload, new PagingParams(null, null, 0L, null));
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).hasSize(5),
+                    () -> assertThat(responses)
+                            .map(ChallengeOfMineResponse::getSuccessCount)
+                            .containsExactly(0, 2, 1, 3, 1),
+                    () -> assertThat(responses)
+                            .map(ChallengeOfMineResponse::getChallengeId)
+                            .containsExactly(스모디_방문하기_ID, 미라클_모닝_ID, 오늘의_운동_ID, JPA_공부_ID, 알고리즘_풀기_ID)
+            );
+        }
+
+        @DisplayName("미래에 시작하는 사이클도 조회한다.")
+        @Test
+        void searchOfMine_retry() {
+            // given
+            fixture.사이클_생성(조조그린_ID, JPA_공부_ID, Progress.NOTHING, now.plusDays(1L));
+            TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
+
+            // when
+            List<ChallengeOfMineResponse> responses = challengeApiService.findAllByMeAndFilter(
+                    tokenPayload, new PagingParams(null, null, 0L, null));
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).hasSize(5),
+                    () -> assertThat(responses)
+                            .map(ChallengeOfMineResponse::getSuccessCount)
+                            .containsExactly(3, 0, 2, 1, 1),
+                    () -> assertThat(responses)
+                            .map(ChallengeOfMineResponse::getChallengeId)
+                            .containsExactly(JPA_공부_ID, 스모디_방문하기_ID, 미라클_모닝_ID, 오늘의_운동_ID, 알고리즘_풀기_ID)
+            );
+        }
+    }
+
+    @DisplayName("하나의 챌린지를 상세 조회할 때 - findWithChallengerCount()")
+    @Nested
+    class FindWithChallengerCount {
+
+        @DisplayName("비회원이 조회")
+        @Test
+        void findOneWithChallengerCount() {
+            // given
+            fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.NOTHING, now);
+            fixture.사이클_생성(더즈_ID, 미라클_모닝_ID, Progress.FIRST, now.minusDays(1L));
+            fixture.사이클_생성(토닉_ID, 미라클_모닝_ID, Progress.SUCCESS, now.minusDays(3L));
+
+            // when
+            ChallengeResponse challengeResponse = challengeApiService.findWithChallengerCount(now, 미라클_모닝_ID);
+
+            // then
+            assertAll(
+                    () -> assertThat(challengeResponse.getChallengerCount()).isEqualTo(2),
+                    () -> assertThat(challengeResponse.getChallengeId()).isEqualTo(미라클_모닝_ID),
+                    () -> assertThat(challengeResponse.getIsInProgress()).isFalse()
+            );
+        }
+
+        @DisplayName("회원이 조회")
+        @Test
+        void findOneWithChallengerCount_auth() {
+            // given
+            TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
+            fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.NOTHING, now);
+            fixture.사이클_생성(더즈_ID, 미라클_모닝_ID, Progress.FIRST, now.minusDays(1L));
+            fixture.사이클_생성(토닉_ID, 미라클_모닝_ID, Progress.SUCCESS, now.minusDays(3L));
+
+            // when
+            ChallengeResponse challengeResponse = challengeApiService
+                    .findWithChallengerCount(tokenPayload, now, 미라클_모닝_ID);
+
+            // then
+            assertAll(
+                    () -> assertThat(challengeResponse.getChallengerCount()).isEqualTo(2),
+                    () -> assertThat(challengeResponse.getChallengeId()).isEqualTo(미라클_모닝_ID),
+                    () -> assertThat(challengeResponse.getIsInProgress()).isTrue()
+            );
+        }
+    }
+
+    @DisplayName("챌린지의 참여자를 조회할 때 - findAllChallengers()")
+    @Nested
+    class FindAllChallengers {
+
+        @DisplayName("챌린지의 참여자를 조회")
+        @Test
+        void findAllChallenger() {
+            // given
+            Member member1 = fixture.회원_조회(조조그린_ID);
+            Member member2 = fixture.회원_조회(더즈_ID);
+            fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.NOTHING, now);
+            fixture.사이클_생성(더즈_ID, 미라클_모닝_ID, Progress.FIRST, now.minusDays(1L));
+            fixture.사이클_생성(토닉_ID, 오늘의_운동_ID, Progress.SUCCESS, now.minusDays(1L));
+
+            // when
+            List<ChallengersResponse> challengersResponse = challengeApiService
+                    .findAllChallengers(미라클_모닝_ID);
+
+            // then
+            assertAll(
+                    () -> assertThat(challengersResponse).hasSize(2),
+                    () -> assertThat(challengersResponse.stream().map(ChallengersResponse::getMemberId))
+                            .containsExactly(member1.getId(), member2.getId()),
+                    () -> assertThat(challengersResponse.stream().map(ChallengersResponse::getNickname))
+                            .containsExactly(member1.getNickname(), member2.getNickname()),
+                    () -> assertThat(challengersResponse.stream().map(ChallengersResponse::getProgressCount))
+                            .containsExactly(0, 1),
+                    () -> assertThat(challengersResponse.stream().map(ChallengersResponse::getPicture))
+                            .containsExactly(member1.getPicture(), member2.getPicture()),
+                    () -> assertThat(challengersResponse.stream().map(ChallengersResponse::getIntroduction))
+                            .containsExactly(member1.getIntroduction(), member2.getIntroduction())
+            );
+        }
+
+        @DisplayName("아무도 진행하지 않는 챌린지의 참여자를 조회할 때")
+        @Test
+        void findAllChallenger_noInprogress() {
+            // given
+            fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.NOTHING, now);
+            fixture.사이클_생성(더즈_ID, 미라클_모닝_ID, Progress.FIRST, now.minusDays(1L));
+            fixture.사이클_생성(토닉_ID, 오늘의_운동_ID, Progress.SUCCESS, now.minusDays(1L));
+
+            // when
+            List<ChallengersResponse> challengersResponse = challengeApiService
+                    .findAllChallengers(알고리즘_풀기_ID);
+
+            // then
+            assertThat(challengersResponse).isEmpty();
+        }
+
+        @DisplayName("존재하지 않는 챌린지의 참여자를 조회할 때")
+        @Test
+        void findAllChallenger_notExists() {
+            // given
+            fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.NOTHING, now);
+            fixture.사이클_생성(더즈_ID, 미라클_모닝_ID, Progress.FIRST, now.minusDays(1L));
+            fixture.사이클_생성(토닉_ID, 오늘의_운동_ID, Progress.SUCCESS, now.minusDays(1L));
+
+            // when then
+            assertThatThrownBy(() -> challengeApiService.findAllChallengers(100L))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("exceptionData")
+                    .isEqualTo(ExceptionData.NOT_FOUND_CHALLENGE);
+        }
     }
 }

--- a/backend/smody/src/test/java/com/woowacourse/smody/challenge/service/ChallengeServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/challenge/service/ChallengeServiceTest.java
@@ -36,7 +36,7 @@ class ChallengeServiceTest extends IntegrationTest {
 
     private final LocalDateTime now = LocalDateTime.now();
 
-    @DisplayName("id로 챌린지를 조회할 때 - search()")
+    @DisplayName("id로 챌린지를 조회할 때")
     @Nested
     class Search {
 
@@ -61,7 +61,7 @@ class ChallengeServiceTest extends IntegrationTest {
         }
     }
 
-    @DisplayName("id로 챌린지를 조회할 때 - findById()")
+    @DisplayName("id로 챌린지를 조회할 때")
     @Nested
     class FindById {
 
@@ -86,7 +86,7 @@ class ChallengeServiceTest extends IntegrationTest {
         }
     }
 
-    @DisplayName("챌린지를 조회할 때 - findAllByFilter()")
+    @DisplayName("챌린지를 조회할 때")
     @Nested
     class FindAllByFilter {
 
@@ -210,7 +210,7 @@ class ChallengeServiceTest extends IntegrationTest {
         }
     }
 
-    @DisplayName("챌린지를 생성할 때 - create()")
+    @DisplayName("챌린지를 생성할 때")
     @Nested
     class Create {
 

--- a/backend/smody/src/test/java/com/woowacourse/smody/challenge/service/ChallengeServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/challenge/service/ChallengeServiceTest.java
@@ -5,7 +5,6 @@ import static com.woowacourse.smody.support.ResourceFixture.더즈_ID;
 import static com.woowacourse.smody.support.ResourceFixture.미라클_모닝_ID;
 import static com.woowacourse.smody.support.ResourceFixture.스모디_방문하기_ID;
 import static com.woowacourse.smody.support.ResourceFixture.알고리즘_풀기_ID;
-import static com.woowacourse.smody.support.ResourceFixture.알파_ID;
 import static com.woowacourse.smody.support.ResourceFixture.오늘의_운동_ID;
 import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
 import static com.woowacourse.smody.support.ResourceFixture.토닉_ID;
@@ -13,20 +12,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.woowacourse.smody.auth.dto.TokenPayload;
-import com.woowacourse.smody.challenge.dto.ChallengeHistoryResponse;
-import com.woowacourse.smody.challenge.dto.ChallengeOfMineResponse;
-import com.woowacourse.smody.challenge.dto.ChallengeResponse;
-import com.woowacourse.smody.challenge.dto.ChallengeTabResponse;
-import com.woowacourse.smody.challenge.dto.ChallengersResponse;
+import com.woowacourse.smody.challenge.domain.Challenge;
 import com.woowacourse.smody.cycle.domain.Progress;
 import com.woowacourse.smody.db_support.PagingParams;
 import com.woowacourse.smody.exception.BusinessException;
 import com.woowacourse.smody.exception.ExceptionData;
-import com.woowacourse.smody.member.domain.Member;
 import com.woowacourse.smody.support.IntegrationTest;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -38,232 +32,63 @@ import org.springframework.beans.factory.annotation.Autowired;
 class ChallengeServiceTest extends IntegrationTest {
 
     @Autowired
-    private ChallengeApiService challengeApiService;
-
-    @Autowired
     private ChallengeService challengeService;
 
     private final LocalDateTime now = LocalDateTime.now();
 
-    @DisplayName("나의 모든 챌린지 중 가장 최근에 성공한 순으로 챌린지를")
+    @DisplayName("id로 챌린지를 조회할 때 - search()")
     @Nested
-    class SearchSuccessOfMineTest {
+    class Search {
 
-        private TokenPayload tokenPayload;
-
-        @BeforeEach
-        void setUp() {
-            tokenPayload = new TokenPayload(조조그린_ID);
-
-            fixture.사이클_생성(조조그린_ID, 스모디_방문하기_ID, Progress.NOTHING, now);
-            fixture.사이클_생성(조조그린_ID, 스모디_방문하기_ID, Progress.FIRST, now.minusDays(3L));
-
-            fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.NOTHING, now.minusSeconds(1L));
-            fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.FIRST, now.minusDays(1L));
-            fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.SUCCESS, now.minusDays(3L));
-            fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.SUCCESS, now.minusDays(6L));
-
-            fixture.사이클_생성(조조그린_ID, 오늘의_운동_ID, Progress.SUCCESS, now.minusDays(9L));
-
-            fixture.사이클_생성(조조그린_ID, JPA_공부_ID, Progress.SUCCESS, now.minusDays(20L));
-            fixture.사이클_생성(조조그린_ID, JPA_공부_ID, Progress.SUCCESS, now.minusDays(23L));
-            fixture.사이클_생성(조조그린_ID, JPA_공부_ID, Progress.SUCCESS, now.minusDays(26L));
-
-            fixture.사이클_생성(조조그린_ID, 알고리즘_풀기_ID, Progress.SUCCESS, now.minusDays(30L));
-        }
-
-        @DisplayName("조회")
+        @DisplayName("성공")
         @Test
-        void searchOfMine() {
+        void success() {
             // when
-            List<ChallengeOfMineResponse> responses = challengeApiService.findAllByMeAndFilter(
-                    tokenPayload, new PagingParams(null, null, 0L, null));
+            Challenge actual = challengeService.search(스모디_방문하기_ID);
 
             // then
-            assertAll(
-                    () -> assertThat(responses).hasSize(5),
-                    () -> assertThat(responses)
-                            .map(ChallengeOfMineResponse::getSuccessCount)
-                            .containsExactly(0, 2, 1, 3, 1),
-                    () -> assertThat(responses)
-                            .map(ChallengeOfMineResponse::getChallengeId)
-                            .containsExactly(스모디_방문하기_ID, 미라클_모닝_ID, 오늘의_운동_ID, JPA_공부_ID, 알고리즘_풀기_ID)
-            );
+            assertThat(actual.getName()).isEqualTo("스모디 방문하기");
         }
 
-        @DisplayName("0페이지의 3개만 조회")
+        @DisplayName("없는 경우 예외를 발생시킨다.")
         @Test
-        void searchOfMine_pageFullSize() {
-            // when
-            List<ChallengeOfMineResponse> responses = challengeApiService.findAllByMeAndFilter(
-                    tokenPayload, new PagingParams(null, 3, 0L, null));
-
+        void notFound_exception() {
             // then
-            assertAll(
-                    () -> assertThat(responses).hasSize(3),
-                    () -> assertThat(responses)
-                            .map(ChallengeOfMineResponse::getSuccessCount)
-                            .containsExactly(0, 2, 1),
-                    () -> assertThat(responses)
-                            .map(ChallengeOfMineResponse::getChallengeId)
-                            .containsExactly(스모디_방문하기_ID, 미라클_모닝_ID, 오늘의_운동_ID)
-            );
-        }
-
-        @DisplayName("1페이지의 2개만 조회")
-        @Test
-        void searchOfMine_pagePartialSize() {
-            // when
-            List<ChallengeOfMineResponse> responses = challengeApiService.findAllByMeAndFilter(
-                    tokenPayload, new PagingParams(null, 2, 미라클_모닝_ID, null));
-
-            // then
-            assertAll(
-                    () -> assertThat(responses).hasSize(2),
-                    () -> assertThat(responses)
-                            .map(ChallengeOfMineResponse::getSuccessCount)
-                            .containsExactly(1, 3),
-                    () -> assertThat(responses)
-                            .map(ChallengeOfMineResponse::getChallengeId)
-                            .containsExactly(오늘의_운동_ID, JPA_공부_ID)
-            );
-        }
-
-        @DisplayName("없는 페이지로 조회")
-        @Test
-        void searchOfMine_pageOverMaxPage() {
-            // when
-            List<ChallengeOfMineResponse> responses = challengeApiService.findAllByMeAndFilter(
-                    tokenPayload, new PagingParams(null, 3, 알고리즘_풀기_ID, null));
-
-            // then
-            assertThat(responses).isEmpty();
-        }
-
-        @DisplayName("성공한 챌린지들만 조회")
-        @Test
-        void searchSuccessOfMine() {
-            // when
-            List<ChallengeOfMineResponse> responses = challengeApiService.findAllByMeAndFilter(
-                    tokenPayload, new PagingParams(null, null, 0L, "success"));
-
-            // then
-            assertAll(
-                    () -> assertThat(responses).hasSize(4),
-                    () -> assertThat(responses)
-                            .map(ChallengeOfMineResponse::getSuccessCount)
-                            .containsExactly(2, 1, 3, 1),
-                    () -> assertThat(responses)
-                            .map(ChallengeOfMineResponse::getChallengeId)
-                            .containsExactly(미라클_모닝_ID, 오늘의_운동_ID, JPA_공부_ID, 알고리즘_풀기_ID)
-            );
-        }
-
-        @DisplayName("내가 성공한 챌린지들의 0페이지의 3개만 조회")
-        @Test
-        void searchSuccessOfMine_pageFullSize() {
-            // when
-            List<ChallengeOfMineResponse> responses = challengeApiService.findAllByMeAndFilter(
-                    tokenPayload, new PagingParams(null, 3, 0L, "success"));
-
-            // then
-            assertAll(
-                    () -> assertThat(responses).hasSize(3),
-                    () -> assertThat(responses)
-                            .map(ChallengeOfMineResponse::getSuccessCount)
-                            .containsExactly(2, 1, 3),
-                    () -> assertThat(responses)
-                            .map(ChallengeOfMineResponse::getChallengeId)
-                            .containsExactly(미라클_모닝_ID, 오늘의_운동_ID, JPA_공부_ID)
-            );
-        }
-
-        @DisplayName("내가 성공한 챌린지들의 1페이지의 2개만 조회")
-        @Test
-        void searchSuccessOfMine_pagePartialSize() {
-            // when
-            List<ChallengeOfMineResponse> responses = challengeApiService.findAllByMeAndFilter(
-                    tokenPayload, new PagingParams(null, 2, 오늘의_운동_ID, "success"));
-
-            // then
-            assertAll(
-                    () -> assertThat(responses).hasSize(2),
-                    () -> assertThat(responses)
-                            .map(ChallengeOfMineResponse::getSuccessCount)
-                            .containsExactly(3, 1),
-                    () -> assertThat(responses)
-                            .map(ChallengeOfMineResponse::getChallengeId)
-                            .containsExactly(JPA_공부_ID, 알고리즘_풀기_ID)
-            );
-        }
-
-        @DisplayName("내가 성공한 챌린지들의 없는 페이지로 조회")
-        @Test
-        void searchSuccessOfMine_pageOverMaxPage() {
-            // when
-            List<ChallengeOfMineResponse> responses = challengeApiService.findAllByMeAndFilter(
-                    tokenPayload, new PagingParams(null, 3, 알고리즘_풀기_ID, "success"));
-
-            // then
-            assertThat(responses).isEmpty();
+            assertThatThrownBy(() -> challengeService.search(0L))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("ExceptionData")
+                    .isEqualTo(ExceptionData.NOT_FOUND_CHALLENGE);
         }
     }
 
-    @DisplayName("내 전체 참여 챌린지 조회에서 같은 인증 시간이라면 id순으로 정렬")
-    @Test
-    void searchOfMine_sameTime() {
-        // given
-        fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.NOTHING, now.minusDays(2L));
-        fixture.사이클_생성(조조그린_ID, 오늘의_운동_ID, Progress.NOTHING, now.minusDays(2L));
-        fixture.사이클_생성(조조그린_ID, 스모디_방문하기_ID, Progress.SECOND, now.minusDays(2L));
-        fixture.사이클_생성(조조그린_ID, 스모디_방문하기_ID, Progress.SUCCESS, now.minusDays(7L));
-        TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
-
-        List<ChallengeOfMineResponse> responses = challengeApiService.findAllByMeAndFilter(
-                tokenPayload, new PagingParams(null, null, 0L, null));
-
-        // then
-        assertAll(
-                () -> assertThat(responses).hasSize(3),
-                () -> assertThat(responses)
-                        .map(ChallengeOfMineResponse::getSuccessCount)
-                        .containsExactly(1, 0, 0),
-                () -> assertThat(responses)
-                        .map(ChallengeOfMineResponse::getChallengeId)
-                        .containsExactly(스모디_방문하기_ID, 미라클_모닝_ID, 오늘의_운동_ID)
-        );
-
-    }
-
-    @DisplayName("내 전체 참여 챌린지 조회에서 미래에 시작하는 사이클도 조회한다.")
-    @Test
-    void searchOfMine_retry() {
-        // given
-        fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.NOTHING, now.minusDays(2L));
-        fixture.사이클_생성(조조그린_ID, 오늘의_운동_ID, Progress.NOTHING, now.minusDays(2L));
-        fixture.사이클_생성(조조그린_ID, 스모디_방문하기_ID, Progress.SECOND, now.minusDays(2L));
-        fixture.사이클_생성(조조그린_ID, 스모디_방문하기_ID, Progress.SUCCESS, now.minusDays(7L));
-        fixture.사이클_생성(조조그린_ID, JPA_공부_ID, Progress.NOTHING, now.plusDays(1L));
-        TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
-
-        List<ChallengeOfMineResponse> responses = challengeApiService.findAllByMeAndFilter(
-                tokenPayload, new PagingParams(null, null, 0L, null));
-
-        // then
-        assertAll(
-                () -> assertThat(responses).hasSize(4),
-                () -> assertThat(responses)
-                        .map(ChallengeOfMineResponse::getSuccessCount)
-                        .containsExactly(0, 1, 0, 0),
-                () -> assertThat(responses)
-                        .map(ChallengeOfMineResponse::getChallengeId)
-                        .containsExactly(JPA_공부_ID, 스모디_방문하기_ID, 미라클_모닝_ID, 오늘의_운동_ID)
-        );
-    }
-
-    @DisplayName("모든 챌린지를 ")
+    @DisplayName("id로 챌린지를 조회할 때 - findById()")
     @Nested
-    class FindAllWithChallengerCountSortTest {
+    class FindById {
+
+        @DisplayName("찾으면 Optional에 담아서 반환한다.")
+        @Test
+        void success() {
+            // when
+            Optional<Challenge> actual = challengeService.findById(스모디_방문하기_ID);
+
+            // then
+            assertThat(actual).isPresent();
+        }
+
+        @DisplayName("못찾으면 Option.empty()를 반환한다.")
+        @Test
+        void notFound() {
+            // when
+            Optional<Challenge> actual = challengeService.findById(0L);
+
+            // then
+            assertThat(actual).isEmpty();
+        }
+    }
+
+    @DisplayName("챌린지를 조회할 때 - findAllByFilter()")
+    @Nested
+    class FindAllByFilter {
 
         @BeforeEach
         void setUp() {
@@ -280,16 +105,13 @@ class ChallengeServiceTest extends IntegrationTest {
         @Test
         void findAllWithChallengerCount_sort() {
             // when
-            List<ChallengeTabResponse> challengeResponses = challengeApiService.findAllWithChallengerCountByFilter(
-                    now, new PagingParams(null, null, 0L, null));
+            List<Challenge> challenges = challengeService.findAllByFilter(new PagingParams(null, null, 0L, null));
 
             // then
             assertAll(
-                    () -> assertThat(challengeResponses).hasSize(5),
-                    () -> assertThat(challengeResponses.stream().mapToLong(ChallengeTabResponse::getChallengeId))
-                            .containsExactly(스모디_방문하기_ID, 미라클_모닝_ID, 오늘의_운동_ID, 알고리즘_풀기_ID, JPA_공부_ID),
-                    () -> assertThat(challengeResponses.stream().mapToInt(ChallengeTabResponse::getChallengerCount))
-                            .containsExactly(2, 1, 0, 0, 0)
+                    () -> assertThat(challenges).hasSize(5),
+                    () -> assertThat(challenges.stream().mapToLong(Challenge::getId))
+                            .containsExactly(스모디_방문하기_ID, 미라클_모닝_ID, 오늘의_운동_ID, 알고리즘_풀기_ID, JPA_공부_ID)
             );
         }
 
@@ -297,16 +119,14 @@ class ChallengeServiceTest extends IntegrationTest {
         @Test
         void findAllWithChallengerCount_pageFullSize() {
             // when
-            List<ChallengeTabResponse> challengeResponses = challengeApiService.findAllWithChallengerCountByFilter(now,
+            List<Challenge> challenges = challengeService.findAllByFilter(
                     new PagingParams(null, 2, 0L, null));
 
             // then
             assertAll(
-                    () -> assertThat(challengeResponses).hasSize(2),
-                    () -> assertThat(challengeResponses.stream().map(ChallengeTabResponse::getChallengeId))
-                            .containsExactly(스모디_방문하기_ID, 미라클_모닝_ID),
-                    () -> assertThat(challengeResponses.stream().mapToInt(ChallengeTabResponse::getChallengerCount))
-                            .containsExactly(2, 1)
+                    () -> assertThat(challenges).hasSize(2),
+                    () -> assertThat(challenges.stream().map(Challenge::getId))
+                            .containsExactly(스모디_방문하기_ID, 미라클_모닝_ID)
             );
         }
 
@@ -314,16 +134,15 @@ class ChallengeServiceTest extends IntegrationTest {
         @Test
         void findAllWithChallengerCount_pagePartialSize() {
             // when
-            List<ChallengeTabResponse> challengeResponses = challengeApiService.findAllWithChallengerCountByFilter(
-                    now, new PagingParams(null, 2, 미라클_모닝_ID, null));
+            List<Challenge> challenges = challengeService.findAllByFilter(
+                    new PagingParams(null, 2, 미라클_모닝_ID, null)
+            );
 
             // then
             assertAll(
-                    () -> assertThat(challengeResponses).hasSize(2),
-                    () -> assertThat(challengeResponses.stream().mapToLong(ChallengeTabResponse::getChallengeId))
-                            .containsExactly(오늘의_운동_ID, 알고리즘_풀기_ID),
-                    () -> assertThat(challengeResponses.stream().mapToInt(ChallengeTabResponse::getChallengerCount))
-                            .containsExactly(0, 0)
+                    () -> assertThat(challenges).hasSize(2),
+                    () -> assertThat(challenges.stream().mapToLong(Challenge::getId))
+                            .containsExactly(오늘의_운동_ID, 알고리즘_풀기_ID)
             );
         }
 
@@ -331,455 +150,134 @@ class ChallengeServiceTest extends IntegrationTest {
         @Test
         void findAllWithChallengerCount_pageOverMaxPage() {
             // when
-            List<ChallengeTabResponse> challengeResponses = challengeApiService.findAllWithChallengerCountByFilter(
-                    now, new PagingParams(null, 3, JPA_공부_ID, null));
+            List<Challenge> challenges = challengeService.findAllByFilter(
+                    new PagingParams(null, 3, JPA_공부_ID, null));
 
             // then
-            assertThat(challengeResponses).isEmpty();
+            assertThat(challenges).isEmpty();
         }
 
-        @DisplayName("회원이 조회")
+        @DisplayName("빈 이름 혹은 공백 문자로 검색하는 경우 예외를 발생시킨다.")
+        @ParameterizedTest
+        @ValueSource(strings = {" ", ""})
+        void searchByName_unAuthorizedWithNoName(String invalidSearchingName) {
+            // when then
+            assertThatThrownBy(() -> challengeService.findAllByFilter(
+                    new PagingParams(null, null, 0L, invalidSearchingName)))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("exceptionData")
+                    .isEqualTo(ExceptionData.INVALID_SEARCH_NAME);
+        }
+
+        @DisplayName("이름 기준으로 검색하는 경우")
         @Test
-        void findAllWithChallengerCount_sortAuth() {
+        void searchByName_authorized() {
             // when
-            TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
-            List<ChallengeTabResponse> challengeResponses = challengeApiService.findAllWithChallengerCountByFilter(
-                    tokenPayload, now, new PagingParams(null, null, 0L, null));
+            List<Challenge> challenges = challengeService.findAllByFilter(new PagingParams(null, null, 0L, "기"));
 
             // then
             assertAll(
-                    () -> assertThat(challengeResponses).hasSize(5),
-                    () -> assertThat(challengeResponses.stream().mapToLong(ChallengeTabResponse::getChallengeId))
-                            .containsExactly(스모디_방문하기_ID, 미라클_모닝_ID, 오늘의_운동_ID, 알고리즘_풀기_ID, JPA_공부_ID),
-                    () -> assertThat(challengeResponses.stream().map(ChallengeTabResponse::getIsInProgress))
-                            .containsExactly(true, true, false, false, false)
+                    () -> assertThat(challenges).hasSize(2),
+                    () -> assertThat(challenges.stream().map(Challenge::getId))
+                            .containsExactly(스모디_방문하기_ID, 알고리즘_풀기_ID)
             );
         }
 
-        @DisplayName("회원이 2개 조회")
+        @DisplayName("이름 기준으로 검색 후 페이지네이션")
         @Test
-        void findAllWithChallengerCount_pageFullSizeAuth() {
+        void searchByName_authorizedCursorPaging() {
             // when
-            TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
-            List<ChallengeTabResponse> challengeResponses = challengeApiService.findAllWithChallengerCountByFilter(
-                    tokenPayload, now, new PagingParams(null, 2, 0L, null));
+            List<Challenge> challenges = challengeService.findAllByFilter(
+                    new PagingParams(null, null, 스모디_방문하기_ID, "기"));
 
             // then
             assertAll(
-                    () -> assertThat(challengeResponses).hasSize(2),
-                    () -> assertThat(challengeResponses.stream().map(ChallengeTabResponse::getChallengeId))
-                            .containsExactly(스모디_방문하기_ID, 미라클_모닝_ID),
-                    () -> assertThat(challengeResponses.stream().mapToInt(ChallengeTabResponse::getChallengerCount))
-                            .containsExactly(2, 1),
-                    () -> assertThat(challengeResponses.stream().map(ChallengeTabResponse::getIsInProgress))
-                            .containsExactly(true, true)
+                    () -> assertThat(challenges).hasSize(1),
+                    () -> assertThat(challenges.stream().map(Challenge::getId))
+                            .containsExactly(알고리즘_풀기_ID)
             );
         }
 
-        @DisplayName("회원이 커서를 기준으로 2개를 조회")
+        @DisplayName("이름 기준으로 검색하고 마지막 커서로 페이지네이션")
         @Test
-        void findAllWithChallengerCount_pagePartialSizeAuth() {
+        void searchByName_authorizedLastCursor() {
             // when
-            TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
-            List<ChallengeTabResponse> challengeResponses = challengeApiService.findAllWithChallengerCountByFilter(
-                    tokenPayload, now, new PagingParams(null, 2, 미라클_모닝_ID, null));
+            List<Challenge> challenges = challengeService.findAllByFilter(
+                    new PagingParams(null, null, 알고리즘_풀기_ID, "기"));
 
             // then
-            assertAll(
-                    () -> assertThat(challengeResponses).hasSize(2),
-                    () -> assertThat(challengeResponses.stream().mapToInt(ChallengeTabResponse::getChallengerCount))
-                            .containsExactly(0, 0),
-                    () -> assertThat(challengeResponses.stream().mapToLong(ChallengeTabResponse::getChallengeId))
-                            .containsExactly(오늘의_운동_ID, 알고리즘_풀기_ID),
-                    () -> assertThat(challengeResponses.stream().map(ChallengeTabResponse::getIsInProgress))
-                            .containsExactly(false, false)
+            assertThat(challenges).isEmpty();
+        }
+    }
+
+    @DisplayName("챌린지를 생성할 때 - create()")
+    @Nested
+    class Create {
+
+        @DisplayName("성공")
+        @Test
+        void create() {
+            // when
+            Long challengeId = challengeService.create(
+                    "1일 1포스팅 챌린지", "1일 1포스팅하는 챌린지입니다", 0, 1
             );
+
+            // when then
+            assertThat(challengeService.search(challengeId)).isNotNull();
         }
 
-        @DisplayName("회원이 데이터의 마지막이 커서이면서 3개 조회")
+        @DisplayName("중복된 챌린지 이름으로 생성하는 경우 예외 발생")
         @Test
-        void findAllWithChallengerCount_pageOverMaxPageAuth() {
+        void create_duplicatedName() {
             // when
-            TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
-            List<ChallengeTabResponse> challengeResponses = challengeApiService.findAllWithChallengerCountByFilter(
-                    tokenPayload, now, new PagingParams(null, 3, JPA_공부_ID, null));
+            Long challengeId = challengeService.create(
+                    "1일 1포스팅 챌린지", "1일 1포스팅하는 챌린지입니다", 0, 1
+            );
 
-            // then
-            assertThat(challengeResponses).isEmpty();
+            // when then
+            assertThat(challengeId).isNotNull();
         }
-    }
 
-    @DisplayName("비회원이 하나의 챌린지를 상세 조회")
-    @Test
-    void findOneWithChallengerCount() {
-        // given
-        fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.NOTHING, now);
-        fixture.사이클_생성(더즈_ID, 미라클_모닝_ID, Progress.FIRST, now.minusDays(1L));
-        fixture.사이클_생성(토닉_ID, 미라클_모닝_ID, Progress.SUCCESS, now.minusDays(3L));
+        @DisplayName("챌린지 소개 내용이 공백문자거나 빈 문자인 경우 예외 발생")
+        @ParameterizedTest
+        @ValueSource(strings = {"   ", ""})
+        void create_emptyDesc(String invalidDescription) {
+            // when then
+            assertThatThrownBy(() -> challengeService.create("1일 1포스팅 챌린지", invalidDescription, 0, 1))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("exceptionData")
+                    .isEqualTo(ExceptionData.INVALID_CHALLENGE_DESCRIPTION);
+        }
 
-        // when
-        ChallengeResponse challengeResponse = challengeApiService.findWithChallengerCount(now, 미라클_모닝_ID);
+        @DisplayName("챌린지 소개 길이가 255자 초과인 경우 예외 발생")
+        @Test
+        void create_overDescriptionSize() {
+            // when then
+            assertThatThrownBy(() -> challengeService.create("1일 1포스팅 챌린지", "a".repeat(256), 0, 1))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("exceptionData")
+                    .isEqualTo(ExceptionData.INVALID_CHALLENGE_DESCRIPTION);
+        }
 
-        // then
-        assertAll(
-                () -> assertThat(challengeResponse.getChallengerCount()).isEqualTo(2),
-                () -> assertThat(challengeResponse.getChallengeId()).isEqualTo(미라클_모닝_ID),
-                () -> assertThat(challengeResponse.getIsInProgress()).isFalse()
-        );
-    }
+        @DisplayName("챌린지 이름 내용이 공백문자거나 빈 문자인 경우 예외 발생")
+        @ParameterizedTest
+        @ValueSource(strings = {"   ", ""})
+        void create_emptyName(String invalidName) {
+            // when then
+            assertThatThrownBy(() -> challengeService.create(invalidName, "1일 1포스팅 챌린지입니다", 0, 1))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("exceptionData")
+                    .isEqualTo(ExceptionData.INVALID_CHALLENGE_NAME);
+        }
 
-    @DisplayName("회원이 하나의 챌린지를 상세 조회")
-    @Test
-    void findOneWithChallengerCount_auth() {
-        // given
-        TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
-        fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.NOTHING, now);
-        fixture.사이클_생성(더즈_ID, 미라클_모닝_ID, Progress.FIRST, now.minusDays(1L));
-        fixture.사이클_생성(토닉_ID, 미라클_모닝_ID, Progress.SUCCESS, now.minusDays(3L));
-
-        // when
-        ChallengeResponse challengeResponse = challengeApiService
-                .findWithChallengerCount(tokenPayload, now, 미라클_모닝_ID);
-
-        // then
-        assertAll(
-                () -> assertThat(challengeResponse.getChallengerCount()).isEqualTo(2),
-                () -> assertThat(challengeResponse.getChallengeId()).isEqualTo(미라클_모닝_ID),
-                () -> assertThat(challengeResponse.getIsInProgress()).isTrue()
-        );
-    }
-
-    @DisplayName("챌린지의 참여자를 조회")
-    @Test
-    void findAllChallenger() {
-        // given
-        Member member1 = fixture.회원_조회(조조그린_ID);
-        Member member2 = fixture.회원_조회(더즈_ID);
-        fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.NOTHING, now);
-        fixture.사이클_생성(더즈_ID, 미라클_모닝_ID, Progress.FIRST, now.minusDays(1L));
-        fixture.사이클_생성(토닉_ID, 오늘의_운동_ID, Progress.SUCCESS, now.minusDays(1L));
-
-        // when
-        List<ChallengersResponse> challengersResponse = challengeApiService
-                .findAllChallengers(미라클_모닝_ID);
-
-        // then
-        assertAll(
-                () -> assertThat(challengersResponse).hasSize(2),
-                () -> assertThat(challengersResponse.stream().map(ChallengersResponse::getMemberId))
-                        .containsExactly(member1.getId(), member2.getId()),
-                () -> assertThat(challengersResponse.stream().map(ChallengersResponse::getNickname))
-                        .containsExactly(member1.getNickname(), member2.getNickname()),
-                () -> assertThat(challengersResponse.stream().map(ChallengersResponse::getProgressCount))
-                        .containsExactly(0, 1),
-                () -> assertThat(challengersResponse.stream().map(ChallengersResponse::getPicture))
-                        .containsExactly(member1.getPicture(), member2.getPicture()),
-                () -> assertThat(challengersResponse.stream().map(ChallengersResponse::getIntroduction))
-                        .containsExactly(member1.getIntroduction(), member2.getIntroduction())
-        );
-    }
-
-    @DisplayName("아무도 진행하지 않는 챌린지의 참여자를 조회할 때")
-    @Test
-    void findAllChallenger_noInprogress() {
-        // given
-        fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.NOTHING, now);
-        fixture.사이클_생성(더즈_ID, 미라클_모닝_ID, Progress.FIRST, now.minusDays(1L));
-        fixture.사이클_생성(토닉_ID, 오늘의_운동_ID, Progress.SUCCESS, now.minusDays(1L));
-
-        // when
-        List<ChallengersResponse> challengersResponse = challengeApiService
-                .findAllChallengers(알고리즘_풀기_ID);
-
-        // then
-        assertThat(challengersResponse).isEmpty();
-    }
-
-    @DisplayName("존재하지 않는 챌린지의 참여자를 조회할 때")
-    @Test
-    void findAllChallenger_notExists() {
-        // given
-        fixture.사이클_생성(조조그린_ID, 미라클_모닝_ID, Progress.NOTHING, now);
-        fixture.사이클_생성(더즈_ID, 미라클_모닝_ID, Progress.FIRST, now.minusDays(1L));
-        fixture.사이클_생성(토닉_ID, 오늘의_운동_ID, Progress.SUCCESS, now.minusDays(1L));
-
-        // when then
-        assertThatThrownBy(() -> challengeApiService.findAllChallengers(100L))
-                .isInstanceOf(BusinessException.class)
-                .extracting("exceptionData")
-                .isEqualTo(ExceptionData.NOT_FOUND_CHALLENGE);
-    }
-
-    @DisplayName("챌린지를 생성하는 경우")
-    @Test
-    void create() {
-        // when
-        Long challengeId = challengeService.create(
-                "1일 1포스팅 챌린지", "1일 1포스팅하는 챌린지입니다", 0, 1
-        );
-
-        // when then
-        assertThat(challengeService.search(challengeId)).isNotNull();
-    }
-
-    @DisplayName("중복된 챌린지 이름으로 생성하는 경우 예외 발생")
-    @Test
-    void create_duplicatedName() {
-        // when
-        Long challengeId = challengeService.create(
-                "1일 1포스팅 챌린지", "1일 1포스팅하는 챌린지입니다", 0, 1
-        );
-
-        // when then
-        assertThat(challengeId).isNotNull();
-    }
-
-    @DisplayName("챌린지 소개 내용이 공백문자거나 빈 문자인 경우 예외 발생")
-    @ParameterizedTest
-    @ValueSource(strings = {"   ", ""})
-    void create_emptyDesc(String invalidDescription) {
-        // when then
-        assertThatThrownBy(() -> challengeService.create("1일 1포스팅 챌린지", invalidDescription, 0, 1))
-                .isInstanceOf(BusinessException.class)
-                .extracting("exceptionData")
-                .isEqualTo(ExceptionData.INVALID_CHALLENGE_DESCRIPTION);
-    }
-
-    @DisplayName("챌린지 소개 길이가 255자 초과인 경우 예외 발생")
-    @Test
-    void create_overDescriptionSize() {
-        // when then
-        assertThatThrownBy(() -> challengeService.create("1일 1포스팅 챌린지", "a".repeat(256), 0, 1))
-                .isInstanceOf(BusinessException.class)
-                .extracting("exceptionData")
-                .isEqualTo(ExceptionData.INVALID_CHALLENGE_DESCRIPTION);
-    }
-
-    @DisplayName("챌린지 이름 내용이 공백문자거나 빈 문자인 경우 예외 발생")
-    @ParameterizedTest
-    @ValueSource(strings = {"   ", ""})
-    void create_emptyName(String invalidName) {
-        // when then
-        assertThatThrownBy(() -> challengeService.create(invalidName, "1일 1포스팅 챌린지입니다", 0, 1))
-                .isInstanceOf(BusinessException.class)
-                .extracting("exceptionData")
-                .isEqualTo(ExceptionData.INVALID_CHALLENGE_NAME);
-    }
-
-    @DisplayName("챌린지 이름 길이가 30자 초과인 경우 예외 발생")
-    @Test
-    void create_overNameSize() {
-        // when then
-        assertThatThrownBy(() -> challengeService.create("a".repeat(31), "1일 1포스팅 챌린지입니다", 0, 1))
-                .isInstanceOf(BusinessException.class)
-                .extracting("exceptionData")
-                .isEqualTo(ExceptionData.INVALID_CHALLENGE_NAME);
-    }
-
-    @DisplayName("비회원이 챌린지를 이름 기준으로 검색하는 경우")
-    @Test
-    void searchByName_unAuthorized() {
-        //given
-        fixture.사이클_생성_NOTHING(알파_ID, 알고리즘_풀기_ID, now);
-        fixture.사이클_생성_NOTHING(토닉_ID, 스모디_방문하기_ID, now);
-        fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, now);
-
-        // when
-        List<ChallengeTabResponse> challengeTabResponse = challengeApiService.findAllWithChallengerCountByFilter(
-                now, new PagingParams(null, null, 0L, "기"));
-
-        // then
-        assertAll(
-                () -> assertThat(challengeTabResponse).hasSize(2),
-                () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getChallengeId))
-                        .containsExactly(스모디_방문하기_ID, 알고리즘_풀기_ID),
-                () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getChallengerCount))
-                        .containsExactly(2, 1),
-                () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getIsInProgress))
-                        .containsExactly(false, false)
-        );
-    }
-
-    @DisplayName("비회원이 챌린지를 이름 기준으로 검색 후 페이지네이션")
-    @Test
-    void searchByName_unAuthorizedCursorPaging() {
-        //given
-        fixture.사이클_생성_NOTHING(알파_ID, 알고리즘_풀기_ID, now);
-        fixture.사이클_생성_NOTHING(토닉_ID, 스모디_방문하기_ID, now);
-        fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, now);
-
-        // when
-        List<ChallengeTabResponse> challengeTabResponse = challengeApiService.findAllWithChallengerCountByFilter(
-                now, new PagingParams(null, null, 스모디_방문하기_ID, "기"));
-
-        // then
-        assertAll(
-                () -> assertThat(challengeTabResponse).hasSize(1),
-                () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getChallengeId))
-                        .containsExactly(알고리즘_풀기_ID),
-                () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getChallengerCount))
-                        .containsExactly(1),
-                () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getIsInProgress))
-                        .containsExactly(false)
-        );
-    }
-
-    @DisplayName("비회원이 챌린지를 이름 기준으로 검색하고 마지막 커서로 페이지네이션")
-    @Test
-    void searchByName_unAuthorizedLastCursor() {
-        //given
-        fixture.사이클_생성_NOTHING(알파_ID, 알고리즘_풀기_ID, now);
-        fixture.사이클_생성_NOTHING(토닉_ID, 스모디_방문하기_ID, now);
-        fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, now);
-
-        // when
-        List<ChallengeTabResponse> challengeTabResponse = challengeApiService.findAllWithChallengerCountByFilter(
-                now, new PagingParams(null, null, 알고리즘_풀기_ID, "기"));
-
-        // then
-        assertThat(challengeTabResponse).isEmpty();
-    }
-
-    @DisplayName("비회원이 챌린지를 빈 이름 혹은 공백 문자로 검색하는 경우")
-    @ParameterizedTest
-    @ValueSource(strings = {" ", ""})
-    void searchByName_unAuthorizedWithNoName(String invalidSearchingName) {
-        //given
-        fixture.사이클_생성_NOTHING(알파_ID, 알고리즘_풀기_ID, now);
-        fixture.사이클_생성_NOTHING(토닉_ID, 스모디_방문하기_ID, now);
-        fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, now);
-
-        // when then
-        assertThatThrownBy(() -> challengeApiService.findAllWithChallengerCountByFilter(
-                now, new PagingParams(null, null, 0L, invalidSearchingName)))
-                .isInstanceOf(BusinessException.class)
-                .extracting("exceptionData")
-                .isEqualTo(ExceptionData.INVALID_SEARCH_NAME);
-    }
-
-    @DisplayName("회원이 챌린지를 이름 기준으로 검색하는 경우")
-    @Test
-    void searchByName_authorized() {
-        //given
-        fixture.사이클_생성_NOTHING(알파_ID, 알고리즘_풀기_ID, now);
-        fixture.사이클_생성_NOTHING(토닉_ID, 스모디_방문하기_ID, now);
-        fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, now);
-        TokenPayload tokenPayload = new TokenPayload(알파_ID);
-
-        // when
-        List<ChallengeTabResponse> challengeTabResponse = challengeApiService.findAllWithChallengerCountByFilter(
-                tokenPayload, now, new PagingParams(null, null, 0L, "기"));
-
-        // then
-        assertAll(
-                () -> assertThat(challengeTabResponse).hasSize(2),
-                () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getChallengeId))
-                        .containsExactly(스모디_방문하기_ID, 알고리즘_풀기_ID),
-                () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getChallengerCount))
-                        .containsExactly(2, 1),
-                () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getIsInProgress))
-                        .containsExactly(false, true)
-        );
-    }
-
-    @DisplayName("회원이 챌린지를 이름 기준으로 검색 후 페이지네이션")
-    @Test
-    void searchByName_authorizedCursorPaging() {
-        //given
-        fixture.사이클_생성_NOTHING(알파_ID, 알고리즘_풀기_ID, now);
-        fixture.사이클_생성_NOTHING(토닉_ID, 스모디_방문하기_ID, now);
-        fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, now);
-        TokenPayload tokenPayload = new TokenPayload(알파_ID);
-
-        // when
-        List<ChallengeTabResponse> challengeTabResponse = challengeApiService.findAllWithChallengerCountByFilter(
-                tokenPayload, now, new PagingParams(null, null, 스모디_방문하기_ID, "기"));
-
-        // then
-        assertAll(
-                () -> assertThat(challengeTabResponse).hasSize(1),
-                () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getChallengeId))
-                        .containsExactly(알고리즘_풀기_ID),
-                () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getChallengerCount))
-                        .containsExactly(1),
-                () -> assertThat(challengeTabResponse.stream().map(ChallengeTabResponse::getIsInProgress))
-                        .containsExactly(true)
-        );
-    }
-
-    @DisplayName("회원이 챌린지를 이름 기준으로 검색하고 마지막 커서로 페이지네이션")
-    @Test
-    void searchByName_authorizedLastCursor() {
-        //given
-        fixture.사이클_생성_NOTHING(알파_ID, 알고리즘_풀기_ID, now);
-        fixture.사이클_생성_NOTHING(토닉_ID, 스모디_방문하기_ID, now);
-        fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, now);
-        TokenPayload tokenPayload = new TokenPayload(알파_ID);
-
-        // when
-        List<ChallengeTabResponse> challengeTabResponse = challengeApiService.findAllWithChallengerCountByFilter(
-                tokenPayload, now, new PagingParams(null, null, 알고리즘_풀기_ID, "기"));
-
-        // then
-        assertThat(challengeTabResponse).isEmpty();
-    }
-
-    @DisplayName("회원이 챌린지를 빈 이름 혹은 공백 문자로 검색하는 경우")
-    @ParameterizedTest
-    @ValueSource(strings = {" ", ""})
-    void searchByName_authorizedWithNoName(String invalidSearchingName) {
-        //given
-        fixture.사이클_생성_NOTHING(알파_ID, 알고리즘_풀기_ID, now);
-        fixture.사이클_생성_NOTHING(토닉_ID, 스모디_방문하기_ID, now);
-        fixture.사이클_생성_NOTHING(더즈_ID, 스모디_방문하기_ID, now);
-        TokenPayload tokenPayload = new TokenPayload(알파_ID);
-
-        // when then
-        assertThatThrownBy(() -> challengeApiService.findAllWithChallengerCountByFilter(
-                tokenPayload, now, new PagingParams(null, null, 0L, invalidSearchingName)))
-                .isInstanceOf(BusinessException.class)
-                .extracting("exceptionData")
-                .isEqualTo(ExceptionData.INVALID_SEARCH_NAME);
-    }
-
-    @DisplayName("회원이 참가한 챌린지 하나를 조회하는 경우")
-    @Test
-    void findOneWithMine() {
-        //given
-        fixture.사이클_생성_FIRST(알파_ID, 알고리즘_풀기_ID, now);
-        fixture.사이클_생성_SUCCESS(알파_ID, 알고리즘_풀기_ID, now.minusDays(3L));
-        fixture.사이클_생성_SUCCESS(알파_ID, 알고리즘_풀기_ID, now.minusDays(6L));
-        fixture.사이클_생성_SECOND(알파_ID, 알고리즘_풀기_ID, now.minusDays(9L));
-
-        TokenPayload tokenPayload = new TokenPayload(알파_ID);
-
-        // when
-        ChallengeHistoryResponse challengeHistoryResponse = challengeApiService.findByMeAndChallenge(
-                tokenPayload, 알고리즘_풀기_ID);
-
-        // then
-        assertAll(
-                () -> assertThat(challengeHistoryResponse.getChallengeName()).isEqualTo("알고리즘 풀기"),
-                () -> assertThat(challengeHistoryResponse.getSuccessCount()).isEqualTo(2),
-                () -> assertThat(challengeHistoryResponse.getCycleDetailCount()).isEqualTo(9)
-        );
-    }
-
-    @DisplayName("회원이 참가하지 않은 챌린지를 조회하는 경우 예외를 던진다.")
-    @Test
-    void findOneWithMine_notParticipate() {
-        //given
-        fixture.사이클_생성_NOTHING(알파_ID, 알고리즘_풀기_ID, now);
-        fixture.사이클_생성_SUCCESS(알파_ID, 알고리즘_풀기_ID, now.minusDays(3L));
-        fixture.사이클_생성_SUCCESS(알파_ID, 알고리즘_풀기_ID, now.minusDays(6L));
-        fixture.사이클_생성_SECOND(알파_ID, 알고리즘_풀기_ID, now.minusDays(9L));
-
-        TokenPayload tokenPayload = new TokenPayload(알파_ID);
-
-        // when, then
-        assertThatThrownBy(() -> challengeApiService.findByMeAndChallenge(tokenPayload, 오늘의_운동_ID))
-                .isInstanceOf(BusinessException.class)
-                .extracting("ExceptionData")
-                .isEqualTo(ExceptionData.DATA_INTEGRITY_ERROR);
+        @DisplayName("챌린지 이름 길이가 30자 초과인 경우 예외 발생")
+        @Test
+        void create_overNameSize() {
+            // when then
+            assertThatThrownBy(() -> challengeService.create("a".repeat(31), "1일 1포스팅 챌린지입니다", 0, 1))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("exceptionData")
+                    .isEqualTo(ExceptionData.INVALID_CHALLENGE_NAME);
+        }
     }
 }

--- a/backend/smody/src/test/java/com/woowacourse/smody/member/service/MemberApiServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/member/service/MemberApiServiceTest.java
@@ -1,0 +1,305 @@
+package com.woowacourse.smody.member.service;
+
+import static com.woowacourse.smody.support.ResourceFixture.미라클_모닝_ID;
+import static com.woowacourse.smody.support.ResourceFixture.알파_ID;
+import static com.woowacourse.smody.support.ResourceFixture.오늘의_운동_ID;
+import static com.woowacourse.smody.support.ResourceFixture.이미지;
+import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+
+import com.woowacourse.smody.auth.dto.TokenPayload;
+import com.woowacourse.smody.cycle.domain.Cycle;
+import com.woowacourse.smody.cycle.repository.CycleRepository;
+import com.woowacourse.smody.db_support.PagingParams;
+import com.woowacourse.smody.exception.BusinessException;
+import com.woowacourse.smody.member.domain.Member;
+import com.woowacourse.smody.member.dto.MemberResponse;
+import com.woowacourse.smody.member.dto.MemberUpdateRequest;
+import com.woowacourse.smody.member.dto.SearchedMemberResponse;
+import com.woowacourse.smody.push.domain.PushCase;
+import com.woowacourse.smody.push.repository.PushNotificationRepository;
+import com.woowacourse.smody.push.repository.PushSubscriptionRepository;
+import com.woowacourse.smody.support.IntegrationTest;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+
+class MemberApiServiceTest extends IntegrationTest {
+
+    @Autowired
+    private MemberApiService memberApiService;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private CycleRepository cycleRepository;
+
+    @Autowired
+    private PushSubscriptionRepository pushSubscriptionRepository;
+
+    @Autowired
+    private PushNotificationRepository pushNotificationRepository;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @DisplayName("나의 정보를 조회한다.")
+    @Test
+    void findByMe() {
+        // given
+        Member member = fixture.회원_조회(조조그린_ID);
+
+        // when
+        MemberResponse actual = memberApiService.findByMe(new TokenPayload(조조그린_ID));
+
+        // then
+        assertAll(
+                () -> assertThat(actual.getNickname()).isEqualTo(member.getNickname()),
+                () -> assertThat(actual.getEmail()).isEqualTo(member.getEmail()),
+                () -> assertThat(actual.getPicture()).isEqualTo(member.getPicture()),
+                () -> assertThat(actual.getIntroduction()).isEqualTo(member.getIntroduction())
+        );
+    }
+
+    @DisplayName("회원을 조회할 때 - findAllByFilter()")
+    @Nested
+    class FindAllByFilter {
+
+        @DisplayName("글자가 없고 커서 ID도 없고 크가가 10일떄")
+        @Test
+        void findAll() {
+            // given
+            PagingParams pagingParams = new PagingParams();
+            fixture.회원_추가("조그린", "a@naver.com");
+            fixture.회원_추가("그랑조", "b@naver.com");
+            fixture.회원_추가("조", "c@naver.com");
+            fixture.회원_추가("양조장", "d@naver.com");
+
+            // when
+            List<SearchedMemberResponse> actual = memberApiService.findAllByFilter(pagingParams);
+
+            // then
+            assertAll(
+                    () -> assertThat(actual).hasSize(8),
+                    () -> assertThat(actual).map(SearchedMemberResponse::getNickname)
+                            .containsExactly("조조그린", "더즈", "토닉", "알파", "조그린", "그랑조", "조", "양조장")
+            );
+        }
+
+        @DisplayName("글자가 없고 커서 ID도 없고 크기가 5일때")
+        @Test
+        void findAll_sizeFive() {
+            // given
+            PagingParams pagingParams = new PagingParams(null, 5);
+            fixture.회원_추가("조그린", "a@naver.com");
+            fixture.회원_추가("그랑조", "b@naver.com");
+            fixture.회원_추가("조", "c@naver.com");
+            fixture.회원_추가("양조장", "d@naver.com");
+
+            // when
+            List<SearchedMemberResponse> actual = memberApiService.findAllByFilter(pagingParams);
+
+            // then
+            assertAll(
+                    () -> assertThat(actual).hasSize(5),
+                    () -> assertThat(actual).map(SearchedMemberResponse::getNickname)
+                            .containsExactly("조조그린", "더즈", "토닉", "알파", "조그린")
+            );
+        }
+
+        @DisplayName("글자가 없고 커서 ID는 있고 크기가 10일 때")
+        @Test
+        void findAll_existCursorId() {
+            // given
+            PagingParams pagingParams = new PagingParams(null, 0, 알파_ID);
+            fixture.회원_추가("조그린", "a@naver.com");
+            fixture.회원_추가("그랑조", "b@naver.com");
+            fixture.회원_추가("조", "c@naver.com");
+            fixture.회원_추가("양조장", "d@naver.com");
+
+            // when
+            List<SearchedMemberResponse> actual = memberApiService.findAllByFilter(pagingParams);
+
+            // then
+            assertAll(
+                    () -> assertThat(actual).hasSize(4),
+                    () -> assertThat(actual).map(SearchedMemberResponse::getNickname)
+                            .containsExactly("조그린", "그랑조", "조", "양조장")
+            );
+        }
+
+        @DisplayName("글자가 없고 커서 ID는 있고 크기가 2일 때")
+        @Test
+        void findAll_existCursorId_sizeTwo() {
+            // given
+            PagingParams pagingParams = new PagingParams(null, 2, 알파_ID);
+            fixture.회원_추가("조그린", "a@naver.com");
+            fixture.회원_추가("그랑조", "b@naver.com");
+            fixture.회원_추가("조", "c@naver.com");
+            fixture.회원_추가("양조장", "d@naver.com");
+
+            // when
+            List<SearchedMemberResponse> actual = memberApiService.findAllByFilter(pagingParams);
+
+            // then
+            assertAll(
+                    () -> assertThat(actual).hasSize(2),
+                    () -> assertThat(actual).map(SearchedMemberResponse::getNickname)
+                            .containsExactly("조그린", "그랑조")
+            );
+        }
+
+        @DisplayName("글자가 있고 커서 ID는 없고 크기가 10일 때")
+        @Test
+        void findAll_existFilter() {
+            // given
+            PagingParams pagingParams = new PagingParams(null, 0, null, "조");
+            fixture.회원_추가("조그린", "a@naver.com");
+            fixture.회원_추가("그랑조", "b@naver.com");
+            fixture.회원_추가("조", "c@naver.com");
+            fixture.회원_추가("양조장", "d@naver.com");
+
+            // when
+            List<SearchedMemberResponse> actual = memberApiService.findAllByFilter(pagingParams);
+
+            // then
+            assertAll(
+                    () -> assertThat(actual).hasSize(5),
+                    () -> assertThat(actual).map(SearchedMemberResponse::getNickname)
+                            .containsExactly("조조그린", "조그린", "그랑조", "조", "양조장")
+            );
+        }
+
+        @DisplayName("글자가 있고 커서 ID는 없고 크기가 3일 때")
+        @Test
+        void findAll_existFilter_sizeThree() {
+            // given
+            PagingParams pagingParams = new PagingParams(null, 3, null, "조");
+            fixture.회원_추가("조그린", "a@naver.com");
+            fixture.회원_추가("그랑조", "b@naver.com");
+            fixture.회원_추가("조", "c@naver.com");
+            fixture.회원_추가("양조장", "d@naver.com");
+
+            // when
+            List<SearchedMemberResponse> actual = memberApiService.findAllByFilter(pagingParams);
+
+            // then
+            assertAll(
+                    () -> assertThat(actual).hasSize(3),
+                    () -> assertThat(actual).map(SearchedMemberResponse::getNickname)
+                            .containsExactly("조조그린", "조그린", "그랑조")
+            );
+        }
+
+        @DisplayName("글자가 있고 커서 ID는 있고 크기가 10일 때")
+        @Test
+        void findAll_existFilter_existCursorId() {
+            // given
+            Member member = fixture.회원_추가("조그린", "a@naver.com");
+            fixture.회원_추가("그랑조", "b@naver.com");
+            fixture.회원_추가("조", "c@naver.com");
+            fixture.회원_추가("양조장", "d@naver.com");
+            PagingParams pagingParams = new PagingParams(null, 0, member.getId(), "조");
+
+            // when
+            List<SearchedMemberResponse> actual = memberApiService.findAllByFilter(pagingParams);
+
+            // then
+            assertAll(
+                    () -> assertThat(actual).hasSize(3),
+                    () -> assertThat(actual).map(SearchedMemberResponse::getNickname)
+                            .containsExactly("그랑조", "조", "양조장")
+            );
+        }
+
+        @DisplayName("글자가 있고 커서 ID는 있고 크기가 2일 때")
+        @Test
+        void findAll_existFilter_existCursorId_sizeTwo() {
+            // given
+            Member member = fixture.회원_추가("조그린", "a@naver.com");
+            fixture.회원_추가("그랑조", "b@naver.com");
+            fixture.회원_추가("조", "c@naver.com");
+            fixture.회원_추가("양조장", "d@naver.com");
+            PagingParams pagingParams = new PagingParams(null, 2, member.getId(), "조");
+
+            // when
+            List<SearchedMemberResponse> actual = memberApiService.findAllByFilter(pagingParams);
+
+            // then
+            assertAll(
+                    () -> assertThat(actual).hasSize(2),
+                    () -> assertThat(actual).map(SearchedMemberResponse::getNickname)
+                            .containsExactly("그랑조", "조")
+            );
+        }
+    }
+
+    @DisplayName("회원의 별명과 설명을 수정한다.")
+    @Test
+    void updateByMe() {
+        // when
+        memberApiService.updateByMe(new TokenPayload(조조그린_ID), new MemberUpdateRequest("토닉", "바뀜"));
+        // then
+        MemberResponse actual = memberApiService.findByMe(new TokenPayload(조조그린_ID));
+        assertAll(
+                () -> assertThat(actual.getNickname()).isEqualTo("토닉"),
+                () -> assertThat(actual.getIntroduction()).isEqualTo("바뀜")
+        );
+    }
+
+    @DisplayName("회원의 프로필 이미지를 수정한다.")
+    @Test
+    void updateProfileImageByMe() {
+        // given
+        fixture.회원_조회(조조그린_ID);
+        MockMultipartFile updateImage = new MockMultipartFile(
+                "updateProgressImage", "updateProgressImage.jpg", "image/jpg", "image".getBytes()
+        );
+        TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
+        given(imageStrategy.extractUrl(updateImage)).willReturn("updateProgressImage.jpg");
+
+        // when
+        memberApiService.updateProfileImageByMe(tokenPayload, updateImage);
+
+        // then
+        MemberResponse actual = memberApiService.findByMe(tokenPayload);
+        assertThat(actual.getPicture()).isEqualTo("updateProgressImage.jpg");
+    }
+
+    @DisplayName("회원 탈퇴를 한다.")
+    @Test
+    void withdraw() {
+        // given
+        Cycle cycle1 = fixture.사이클_생성_NOTHING(조조그린_ID, 미라클_모닝_ID, LocalDateTime.now());
+        Cycle cycle2 = fixture.사이클_생성_NOTHING(조조그린_ID, 오늘의_운동_ID, LocalDateTime.now());
+        cycle1.increaseProgress(LocalDateTime.now(), 이미지, "인증 완료");
+        cycle2.increaseProgress(LocalDateTime.now(), 이미지, "인증 완료");
+        fixture.알림_구독(조조그린_ID, "endpoint");
+        fixture.발송_예정_알림_생성(조조그린_ID, null, LocalDateTime.now(), PushCase.SUBSCRIPTION);
+
+        // when
+        memberApiService.withdraw(new TokenPayload(조조그린_ID));
+
+        // then
+        assertAll(
+                () -> assertThatThrownBy(() -> memberService.search(조조그린_ID))
+                        .isInstanceOf(BusinessException.class),
+                () -> assertThat(cycleRepository.findAll())
+                        .isEmpty(),
+                () -> assertThat(em.createQuery("select cd from CycleDetail cd").getResultList())
+                        .isEmpty(),
+                () -> assertThat(pushNotificationRepository.findAll()).isEmpty(),
+                () -> assertThat(pushSubscriptionRepository.findAll()).isEmpty()
+        );
+    }
+}

--- a/backend/smody/src/test/java/com/woowacourse/smody/member/service/MemberApiServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/member/service/MemberApiServiceTest.java
@@ -71,7 +71,7 @@ class MemberApiServiceTest extends IntegrationTest {
         );
     }
 
-    @DisplayName("회원을 조회할 때 - findAllByFilter()")
+    @DisplayName("회원을 조회할 때")
     @Nested
     class FindAllByFilter {
 
@@ -249,6 +249,7 @@ class MemberApiServiceTest extends IntegrationTest {
     void updateByMe() {
         // when
         memberApiService.updateByMe(new TokenPayload(조조그린_ID), new MemberUpdateRequest("토닉", "바뀜"));
+
         // then
         MemberResponse actual = memberApiService.findByMe(new TokenPayload(조조그린_ID));
         assertAll(

--- a/backend/smody/src/test/java/com/woowacourse/smody/member/service/MemberServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/member/service/MemberServiceTest.java
@@ -56,34 +56,40 @@ class MemberServiceTest extends IntegrationTest {
     @PersistenceContext
     private EntityManager em;
 
-    @DisplayName("자신의 회원 정보 조회를 한다.")
-    @Test
-    void search() {
-        // when
-        Member expected = fixture.회원_조회(조조그린_ID);
-        Member actual = memberService.search(조조그린_ID);
+    @DisplayName("자신의 회원정보를 조회할 때")
+    @Nested
+    class Search {
 
-        // then
-        assertAll(
-                () -> assertThat(actual.getEmail()).isEqualTo(expected.getEmail()),
-                () -> assertThat(actual.getNickname()).isEqualTo(expected.getNickname()),
-                () -> assertThat(actual.getPicture()).isEqualTo(expected.getPicture())
-        );
+        @DisplayName("조회")
+        @Test
+        void search() {
+            // when
+            Member expected = fixture.회원_조회(조조그린_ID);
+            Member actual = memberService.search(조조그린_ID);
+
+            // then
+            assertAll(
+                    () -> assertThat(actual.getEmail()).isEqualTo(expected.getEmail()),
+                    () -> assertThat(actual.getNickname()).isEqualTo(expected.getNickname()),
+                    () -> assertThat(actual.getPicture()).isEqualTo(expected.getPicture())
+            );
+        }
+
+        @DisplayName("회원이 존재하지 않는 경우 예외를 발생시킨다.")
+        @Test
+        void searchMyInfo_notExist() {
+            // when then
+            assertThatThrownBy(() -> memberService.search(Long.MAX_VALUE))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("exceptionData")
+                    .isEqualTo(ExceptionData.NOT_FOUND_MEMBER);
+        }
     }
 
-    @DisplayName("자신의 회원 정보 조회할 때 회원이 존재하지 않는 경우 예외를 발생시킨다.")
-    @Test
-    void searchMyInfo_notExist() {
-        // when then
-        assertThatThrownBy(() -> memberService.search(Long.MAX_VALUE))
-                .isInstanceOf(BusinessException.class)
-                .extracting("exceptionData")
-                .isEqualTo(ExceptionData.NOT_FOUND_MEMBER);
-    }
 
     @DisplayName("자신의 회원 정보를 수정한다.")
     @Test
-    void updateMyInfo() {
+    void updateByMe() {
         // when
         memberService.updateByMe(조조그린_ID, "쬬그린", "나는 쬬그린");
 
@@ -124,7 +130,7 @@ class MemberServiceTest extends IntegrationTest {
 
     @DisplayName("회원을 프로필 이미지를 수정한다.")
     @Test
-    void updateProfileImage() {
+    void updateProfileImageByMe() {
         // given
         String expected = "https://www.abc.com/profile.jpg";
         given(imageStrategy.extractUrl(any()))
@@ -231,9 +237,9 @@ class MemberServiceTest extends IntegrationTest {
         assertThat(memberService.findByEmail("email@email.com")).isPresent();
     }
 
-    @DisplayName("회원을 조회할 때 - findAllByFilter()")
+    @DisplayName("회원을 조회할 때")
     @Nested
-    class FindMembersTest {
+    class FindAllByFilter {
 
         @DisplayName("글자가 없고 커서 ID도 없고 크가가 10일떄")
         @Test

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/WebPushBatchTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/WebPushBatchTest.java
@@ -60,7 +60,7 @@ class WebPushBatchTest extends IntegrationTest {
     @Test
     void sendPushNotifications() {
         // given
-        given(webPushService.sendNotification(any(), any()))
+        given(webPushApi.sendNotification(any(), any()))
                 .willReturn(true);
 
         // when
@@ -70,7 +70,7 @@ class WebPushBatchTest extends IntegrationTest {
         List<PushNotification> result = pushNotificationRepository.findByPushStatus(PushStatus.COMPLETE);
         assertAll(
                 () -> assertThat(result).hasSize(2),
-                () -> verify(webPushService, times(1))
+                () -> verify(webPushApi, times(1))
                         .sendNotification(any(), any())
         );
     }
@@ -79,7 +79,7 @@ class WebPushBatchTest extends IntegrationTest {
     @Test
     void sendPushNotifications_notComplete() {
         // given
-        given(webPushService.sendNotification(any(), any()))
+        given(webPushApi.sendNotification(any(), any()))
                 .willReturn(false);
 
         // when
@@ -89,7 +89,7 @@ class WebPushBatchTest extends IntegrationTest {
         List<PushNotification> result = pushNotificationRepository.findByPushStatus(PushStatus.COMPLETE);
         assertAll(
                 () -> assertThat(result).hasSize(1),
-                () -> verify(webPushService, times(1))
+                () -> verify(webPushApi, times(1))
                         .sendNotification(any(), any())
         );
     }
@@ -98,7 +98,7 @@ class WebPushBatchTest extends IntegrationTest {
     @Test
     void sendPushNotifications_deleteSubscriptions() {
         // given
-        given(webPushService.sendNotification(any(), any()))
+        given(webPushApi.sendNotification(any(), any()))
                 .willReturn(false);
 
         // when

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/controller/PushSubscriptionControllerTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/controller/PushSubscriptionControllerTest.java
@@ -30,7 +30,7 @@ class PushSubscriptionControllerTest extends ControllerTest {
     void getPublicKey() throws Exception {
         // given
         String publicKey = "BNzzfdcBcThU27FcGve6F3GF6He2Fro82ZMuOLga9fukatLMlaKB6GdO-82loi6W4iGdPQZAp_4HLgST8z5of_E";
-        given(webPushService.getPublicKey())
+        given(webPushApi.getPublicKey())
                 .willReturn(publicKey);
 
         // when

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/event/CommentPushEventListenerTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/event/CommentPushEventListenerTest.java
@@ -62,7 +62,7 @@ class CommentPushEventListenerTest extends IntegrationTest {
 			() -> assertThat(pushNotification.getMessage()).isEqualTo("더즈님께서 회원님의 피드에 댓글을 남겼어요!"),
 			() -> assertThat(pushNotification.getPushCase()).isEqualTo(PushCase.COMMENT),
 			() -> assertThat(pushNotification.getPathId()).isEqualTo(cycleDetail.getId()),
-			() -> verify(webPushService, never())
+			() -> verify(webPushApi, never())
 				.sendNotification(any(), any())
 		);
 	}
@@ -81,7 +81,7 @@ class CommentPushEventListenerTest extends IntegrationTest {
 		List<PushNotification> results = pushNotificationRepository.findByPushStatus(PushStatus.COMPLETE);
 		assertAll(
 			() -> assertThat(results).isEmpty(),
-			() -> verify(webPushService, never())
+			() -> verify(webPushApi, never())
 				.sendNotification(any(), any())
 		);
 	}

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/service/PushNotificationApiServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/service/PushNotificationApiServiceTest.java
@@ -23,6 +23,7 @@ import com.woowacourse.smody.support.IntegrationTest;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -34,114 +35,136 @@ public class PushNotificationApiServiceTest extends IntegrationTest {
     @Autowired
     private PushNotificationRepository pushNotificationRepository;
 
-    @DisplayName("회원의 발송된 알림을 시간 내림차순으로 모두 가져온다.")
-    @Test
-    void findByMember() {
-        // given
-        LocalDateTime now = LocalDateTime.now();
+    @DisplayName("발송된 알림을 시간 내림차순으로 조회할 때 - searchNotificationsByMe()")
+    @Nested
+    class SearchNotificationsByMe {
 
-        PushNotification notification1 = fixture.발송된_알림_생성(
-                조조그린_ID, null, now.minusHours(2L), PushCase.SUBSCRIPTION
-        );
-        PushNotification notification2 = fixture.발송된_알림_생성(
-                조조그린_ID, 1L, now.minusHours(1L), PushCase.CHALLENGE
-        );
-        PushNotification notification3 = fixture.발송된_알림_생성(
-                조조그린_ID, 2L, now, PushCase.CHALLENGE
-        );
+        @DisplayName("성공")
+        @Test
+        void success() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
 
-        fixture.발송된_알림_생성(더즈_ID, 3L, now.minusHours(3L), PushCase.CHALLENGE);
-        fixture.발송_예정_알림_생성(
-                조조그린_ID, 2L, now.plusHours(1L), PushCase.CHALLENGE
-        );
+            PushNotification notification1 = fixture.발송된_알림_생성(
+                    조조그린_ID, null, now.minusHours(2L), PushCase.SUBSCRIPTION
+            );
+            PushNotification notification2 = fixture.발송된_알림_생성(
+                    조조그린_ID, 1L, now.minusHours(1L), PushCase.CHALLENGE
+            );
+            PushNotification notification3 = fixture.발송된_알림_생성(
+                    조조그린_ID, 2L, now, PushCase.CHALLENGE
+            );
 
-        // when
-        List<PushNotificationResponse> responses = pushNotificationApiService.searchNotificationsByMe(
-                new TokenPayload(조조그린_ID));
+            fixture.발송된_알림_생성(더즈_ID, 3L, now.minusHours(3L), PushCase.CHALLENGE);
+            fixture.발송_예정_알림_생성(
+                    조조그린_ID, 2L, now.plusHours(1L), PushCase.CHALLENGE
+            );
 
-        // then
-        assertAll(
-                () -> assertThat(responses).hasSize(3),
-                () -> assertThat(responses)
-                        .map(PushNotificationResponse::getPushNotificationId)
-                        .containsExactly(notification3.getId(), notification2.getId(), notification1.getId()),
-                () -> assertThat(responses)
-                        .map(PushNotificationResponse::getPushCase)
-                        .containsExactly("challenge", "challenge", "subscription")
-        );
+            // when
+            List<PushNotificationResponse> responses = pushNotificationApiService.searchNotificationsByMe(
+                    new TokenPayload(조조그린_ID));
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).hasSize(3),
+                    () -> assertThat(responses)
+                            .map(PushNotificationResponse::getPushNotificationId)
+                            .containsExactly(notification3.getId(), notification2.getId(), notification1.getId()),
+                    () -> assertThat(responses)
+                            .map(PushNotificationResponse::getPushCase)
+                            .containsExactly("challenge", "challenge", "subscription")
+            );
+        }
     }
 
-    @DisplayName("알림을 삭제한다.")
-    @Test
-    void delete() {
-        // given
-        PushNotification notification = fixture.발송된_알림_생성(
-                조조그린_ID, null, LocalDateTime.now().minusHours(2L), PushCase.SUBSCRIPTION
-        );
+    @DisplayName("알림을 삭제할 때 - deleteById()")
+    @Nested
+    class DeleteById {
 
-        // when
-        pushNotificationApiService.deleteById(notification.getId());
+        @DisplayName("성공")
+        @Test
+        void delete() {
+            // given
+            PushNotification notification = fixture.발송된_알림_생성(
+                    조조그린_ID, null, LocalDateTime.now().minusHours(2L), PushCase.SUBSCRIPTION
+            );
 
-        // then
-        List<PushNotificationResponse> responses = pushNotificationApiService.searchNotificationsByMe(
-                new TokenPayload(조조그린_ID));
-        assertThat(responses).isEmpty();
+            // when
+            pushNotificationApiService.deleteById(notification.getId());
+
+            // then
+            List<PushNotificationResponse> responses = pushNotificationApiService.searchNotificationsByMe(
+                    new TokenPayload(조조그린_ID));
+            assertThat(responses).isEmpty();
+        }
     }
 
-    @DisplayName("알람을 저장한다.")
-    @Test
-    void saveNotification() {
-        // given
-        LocalDateTime now = LocalDateTime.now();
-        TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
-        Cycle cycle = fixture.사이클_생성_FIRST(조조그린_ID, 미라클_모닝_ID, now);
-        CycleDetail cycleDetail = cycle.getCycleDetailsOrderByProgress().get(0);
-        List<Long> ids = List.of(토닉_ID, 더즈_ID);
-        MentionNotificationRequest mentionNotificationRequest =
-                new MentionNotificationRequest(ids, cycleDetail.getId());
+    @DisplayName("알림을 저장할 때 - saveNotification()")
+    @Nested
+    class SaveNotification {
 
-        // when
-        pushNotificationApiService.saveNotification(tokenPayload, mentionNotificationRequest);
+        @DisplayName("성공")
+        @Test
+        void saveNotification() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
+            Cycle cycle = fixture.사이클_생성_FIRST(조조그린_ID, 미라클_모닝_ID, now);
+            CycleDetail cycleDetail = cycle.getCycleDetailsOrderByProgress().get(0);
+            List<Long> ids = List.of(토닉_ID, 더즈_ID);
+            MentionNotificationRequest mentionNotificationRequest =
+                    new MentionNotificationRequest(ids, cycleDetail.getId());
 
-        // then
-        PushNotification pushNotification1 = pushNotificationRepository.findByPushStatus(PushStatus.IN_COMPLETE).get(0);
-        PushNotification pushNotification2 = pushNotificationRepository.findByPushStatus(PushStatus.IN_COMPLETE).get(1);
-        assertAll(
-                () -> assertThat(pushNotification1.getMember().getId()).isEqualTo(더즈_ID),
-                () -> assertThat(pushNotification1.getPushStatus()).isEqualTo(PushStatus.IN_COMPLETE),
-                () -> assertThat(pushNotification1.getMessage()).isEqualTo("조조그린님께서 회원님을 언급하셨습니다!"),
-                () -> assertThat(pushNotification1.getPushCase()).isEqualTo(PushCase.MENTION),
-                () -> assertThat(pushNotification1.getPathId()).isEqualTo(cycleDetail.getId()),
-                () -> verify(webPushService, never())
-                        .sendNotification(any(), any()),
+            // when
+            pushNotificationApiService.saveNotification(tokenPayload, mentionNotificationRequest);
 
-                () -> assertThat(pushNotification2.getMember().getId()).isEqualTo(토닉_ID),
-                () -> assertThat(pushNotification2.getPushStatus()).isEqualTo(PushStatus.IN_COMPLETE),
-                () -> assertThat(pushNotification2.getMessage()).isEqualTo("조조그린님께서 회원님을 언급하셨습니다!"),
-                () -> assertThat(pushNotification2.getPushCase()).isEqualTo(PushCase.MENTION),
-                () -> assertThat(pushNotification2.getPathId()).isEqualTo(cycleDetail.getId()),
-                () -> verify(webPushService, never())
-                        .sendNotification(any(), any())
-        );
+            // then
+            PushNotification pushNotification1 = pushNotificationRepository.findByPushStatus(PushStatus.IN_COMPLETE)
+                    .get(0);
+            PushNotification pushNotification2 = pushNotificationRepository.findByPushStatus(PushStatus.IN_COMPLETE)
+                    .get(1);
+            assertAll(
+                    () -> assertThat(pushNotification1.getMember().getId()).isEqualTo(더즈_ID),
+                    () -> assertThat(pushNotification1.getPushStatus()).isEqualTo(PushStatus.IN_COMPLETE),
+                    () -> assertThat(pushNotification1.getMessage()).isEqualTo("조조그린님께서 회원님을 언급하셨습니다!"),
+                    () -> assertThat(pushNotification1.getPushCase()).isEqualTo(PushCase.MENTION),
+                    () -> assertThat(pushNotification1.getPathId()).isEqualTo(cycleDetail.getId()),
+                    () -> verify(webPushApi, never())
+                            .sendNotification(any(), any()),
+
+                    () -> assertThat(pushNotification2.getMember().getId()).isEqualTo(토닉_ID),
+                    () -> assertThat(pushNotification2.getPushStatus()).isEqualTo(PushStatus.IN_COMPLETE),
+                    () -> assertThat(pushNotification2.getMessage()).isEqualTo("조조그린님께서 회원님을 언급하셨습니다!"),
+                    () -> assertThat(pushNotification2.getPushCase()).isEqualTo(PushCase.MENTION),
+                    () -> assertThat(pushNotification2.getPathId()).isEqualTo(cycleDetail.getId()),
+                    () -> verify(webPushApi, never())
+                            .sendNotification(any(), any())
+            );
+        }
     }
 
-    @DisplayName("회원의 보낸 상태의 알림을 모두 삭제한다.")
-    @Test
-    void deleteMyCompleteNotifications() {
-        // given
-        LocalDateTime now = LocalDateTime.now();
-        TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
+    @DisplayName("보낸 상태의 알림을 모두 삭제할 때 - deleteMyCompleteNotifications()")
+    @Nested
+    class DeleteMyCompleteNotifications {
 
-        fixture.발송된_알림_생성(조조그린_ID, 1L, now.minusHours(2), PushCase.COMMENT);
-        fixture.발송된_알림_생성(조조그린_ID, 1L, now.minusHours(2), PushCase.CHALLENGE);
+        @DisplayName("성공")
+        @Test
+        void success() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            TokenPayload tokenPayload = new TokenPayload(조조그린_ID);
 
-        fixture.발송_예정_알림_생성(조조그린_ID, 1L, now.plusMinutes(2), PushCase.SUBSCRIPTION);
-        fixture.발송된_알림_생성(더즈_ID, 1L, now.plusMinutes(2), PushCase.SUBSCRIPTION);
+            fixture.발송된_알림_생성(조조그린_ID, 1L, now.minusHours(2), PushCase.COMMENT);
+            fixture.발송된_알림_생성(조조그린_ID, 1L, now.minusHours(2), PushCase.CHALLENGE);
 
-        // when
-        pushNotificationApiService.deleteMyCompleteNotifications(tokenPayload);
+            fixture.발송_예정_알림_생성(조조그린_ID, 1L, now.plusMinutes(2), PushCase.SUBSCRIPTION);
+            fixture.발송된_알림_생성(더즈_ID, 1L, now.plusMinutes(2), PushCase.SUBSCRIPTION);
 
-        // then
-        assertThat(pushNotificationRepository.findAll()).hasSize(2);
+            // when
+            pushNotificationApiService.deleteMyCompleteNotifications(tokenPayload);
+
+            // then
+            assertThat(pushNotificationRepository.findAll()).hasSize(2);
+        }
     }
 }

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/service/PushNotificationServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/service/PushNotificationServiceTest.java
@@ -4,7 +4,11 @@ import static com.woowacourse.smody.support.ResourceFixture.더즈_ID;
 import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
 import static com.woowacourse.smody.support.ResourceFixture.토닉_ID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.smody.exception.BusinessException;
+import com.woowacourse.smody.exception.ExceptionData;
 import com.woowacourse.smody.member.domain.Member;
 import com.woowacourse.smody.push.domain.PushCase;
 import com.woowacourse.smody.push.domain.PushNotification;
@@ -13,7 +17,9 @@ import com.woowacourse.smody.push.repository.PushNotificationRepository;
 import com.woowacourse.smody.support.IntegrationTest;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -25,67 +31,187 @@ class PushNotificationServiceTest extends IntegrationTest {
     @Autowired
     private PushNotificationRepository pushNotificationRepository;
 
-    @DisplayName("발송 가능한 알림을 조회한다.")
-    @Test
-    void searchPushable() {
-        // given
-        LocalDateTime now = LocalDateTime.now();
+    @DisplayName("푸시 알림을 생성할 때 - create()")
+    @Nested
+    class Create {
 
-        fixture.발송_예정_알림_생성(조조그린_ID, 1L, now.minusMinutes(2L), PushCase.SUBSCRIPTION);
-        fixture.발송_예정_알림_생성(더즈_ID, 2L, now.minusMinutes(3L), PushCase.CHALLENGE);
+        @DisplayName("성공")
+        @Test
+        void success() {
+            // given
+            Member member = fixture.회원_조회(조조그린_ID);
+            PushNotification pushNotification = new PushNotification(
+                    "알림", LocalDateTime.now(), PushStatus.IN_COMPLETE, member, PushCase.CHALLENGE, 1L
+            );
 
-        fixture.발송_예정_알림_생성(조조그린_ID, 3L, now.plusMinutes(2L), PushCase.CHALLENGE);
-        fixture.발송된_알림_생성(토닉_ID, 4L, now.minusHours(1L), PushCase.CHALLENGE);
+            // when
+            pushNotificationService.create(pushNotification);
 
-        // when
-        List<PushNotification> actual = pushNotificationService.searchPushable();
-
-        // then
-        assertThat(actual)
-                .map(PushNotification::getPathId)
-                .containsOnly(1L, 2L);
+            // then
+            assertThat(pushNotificationRepository.findById(pushNotification.getId())).isPresent();
+        }
     }
 
-    @DisplayName("알림들을 모두 발송 완료 상태로 변경한다.")
-    @Test
-    void completeAll() {
-        // given
-        LocalDateTime now = LocalDateTime.now();
+    @DisplayName("같은 경로, 상태를 가진 알림을 조회할 때 - searchSamePathAndStatusAndPushCase()")
+    @Nested
+    class SearchSamePathAndStatusAndPushCase {
 
-        List<PushNotification> notifications = List.of(
-                fixture.발송_예정_알림_생성(조조그린_ID, 1L, now.minusMinutes(2L), PushCase.SUBSCRIPTION),
-                fixture.발송_예정_알림_생성(더즈_ID, 2L, now.minusMinutes(3L), PushCase.CHALLENGE),
+        @DisplayName("조회")
+        @Test
+        void success() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            fixture.발송_예정_알림_생성(조조그린_ID, 1L, now, PushCase.COMMENT);
+            PushNotification expected = fixture.발송_예정_알림_생성(조조그린_ID, 1L, now, PushCase.CHALLENGE);
+            fixture.발송된_알림_생성(조조그린_ID, 1L, now, PushCase.CHALLENGE);
 
-                fixture.발송_예정_알림_생성(조조그린_ID, 3L, now.minusMinutes(2L), PushCase.CHALLENGE),
-                fixture.발송_예정_알림_생성(토닉_ID, 4L, now.minusHours(1L), PushCase.CHALLENGE)
-        );
+            // when
+            Optional<PushNotification> pushNotification =
+                    pushNotificationService.searchByPathAndStatusAndPushCase(
+                            1L, PushStatus.IN_COMPLETE, PushCase.CHALLENGE
+                    );
 
-        // when
-        pushNotificationService.completeAll(notifications);
-
-        // then
-        assertThat(pushNotificationRepository.findAll())
-                .map(PushNotification::getPushStatus)
-                .containsExactly(PushStatus.COMPLETE, PushStatus.COMPLETE, PushStatus.COMPLETE, PushStatus.COMPLETE);
+            // then
+            PushNotification actual = pushNotification.get();
+            assertThat(actual.getId()).isEqualTo(expected.getId());
+        }
     }
 
-    @DisplayName("회원으로 보낸 알림을 모두 삭제한다.")
-    @Test
-    void deleteByMember() {
-        // given
-        LocalDateTime now = LocalDateTime.now();
-        Member member = fixture.회원_조회(조조그린_ID);
+    @DisplayName("푸시를 할 수 있는 알림을 조회할 때 - searchPushable()")
+    @Nested
+    class SearchPushable {
 
-        fixture.발송된_알림_생성(조조그린_ID, 1L, now.minusHours(2), PushCase.COMMENT);
-        fixture.발송된_알림_생성(조조그린_ID, 1L, now.minusHours(2), PushCase.CHALLENGE);
+        @DisplayName("발송 가능한 알림을 조회한다.")
+        @Test
+        void searchPushable() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
 
-        fixture.발송_예정_알림_생성(조조그린_ID, 1L, now.plusMinutes(2), PushCase.SUBSCRIPTION);
-        fixture.발송된_알림_생성(더즈_ID, 1L, now.plusMinutes(2), PushCase.SUBSCRIPTION);
+            fixture.발송_예정_알림_생성(조조그린_ID, 1L, now.minusMinutes(2L), PushCase.SUBSCRIPTION);
+            fixture.발송_예정_알림_생성(더즈_ID, 2L, now.minusMinutes(3L), PushCase.CHALLENGE);
 
-        // when
-        pushNotificationService.deleteCompletedByMember(member);
+            fixture.발송_예정_알림_생성(조조그린_ID, 3L, now.plusMinutes(2L), PushCase.CHALLENGE);
+            fixture.발송된_알림_생성(토닉_ID, 4L, now.minusHours(1L), PushCase.CHALLENGE);
 
-        // then
-        assertThat(pushNotificationRepository.findAll()).hasSize(2);
+            // when
+            List<PushNotification> actual = pushNotificationService.searchPushable();
+
+            // then
+            assertThat(actual)
+                    .map(PushNotification::getPathId)
+                    .containsOnly(1L, 2L);
+        }
+    }
+
+    @DisplayName("알림 상태의 상태를 보냄으로 수정할 때 - completeAll()")
+    @Nested
+    class CompleteAll {
+
+        @DisplayName("알림들을 모두 발송 완료 상태로 변경한다.")
+        @Test
+        void completeAll() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+
+            List<PushNotification> notifications = List.of(
+                    fixture.발송_예정_알림_생성(조조그린_ID, 1L, now.minusMinutes(2L), PushCase.SUBSCRIPTION),
+                    fixture.발송_예정_알림_생성(더즈_ID, 2L, now.minusMinutes(3L), PushCase.CHALLENGE),
+
+                    fixture.발송_예정_알림_생성(조조그린_ID, 3L, now.minusMinutes(2L), PushCase.CHALLENGE),
+                    fixture.발송_예정_알림_생성(토닉_ID, 4L, now.minusHours(1L), PushCase.CHALLENGE)
+            );
+
+            // when
+            pushNotificationService.completeAll(notifications);
+
+            // then
+            assertThat(pushNotificationRepository.findAll())
+                    .map(PushNotification::getPushStatus)
+                    .containsExactly(PushStatus.COMPLETE, PushStatus.COMPLETE, PushStatus.COMPLETE,
+                            PushStatus.COMPLETE);
+        }
+    }
+
+    @DisplayName("알림을 보낸 시간 순으로 정렬하여 조회할 때 - findAllLatest()")
+    @Nested
+    class FindAllLatest {
+
+        @DisplayName("조회")
+        @Test
+        void findAllLatest() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            fixture.발송된_알림_생성(조조그린_ID, 1L, now, PushCase.CHALLENGE);
+            fixture.발송된_알림_생성(조조그린_ID, 2L, now.minusDays(1), PushCase.CHALLENGE);
+            fixture.발송된_알림_생성(조조그린_ID, 3L, now.minusDays(2), PushCase.CHALLENGE);
+            fixture.발송된_알림_생성(조조그린_ID, 4L, now.minusDays(3), PushCase.CHALLENGE);
+            fixture.발송_예정_알림_생성(조조그린_ID, 5L, now.minusDays(4), PushCase.CHALLENGE);
+            Member member = fixture.회원_조회(조조그린_ID);
+
+            // when
+            List<PushNotification> actual = pushNotificationService.findAllLatest(member, PushStatus.COMPLETE);
+
+            // then
+            assertAll(
+                    () -> assertThat(actual).hasSize(4),
+                    () -> assertThat(actual).map(PushNotification::getPathId)
+                            .containsExactly(1L, 2L, 3L, 4L)
+            );
+        }
+    }
+
+    @DisplayName("id에 맞는 알림을 삭제할 때 - deleteById()")
+    @Nested
+    class DeleteById {
+
+        @DisplayName("성공")
+        @Test
+        void success() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            PushNotification pushNotification = fixture.발송된_알림_생성(조조그린_ID, 1L, now, PushCase.CHALLENGE);
+
+            // when
+            pushNotificationService.deleteById(pushNotification.getId());
+
+            // then
+            Optional<PushNotification> actual = pushNotificationRepository.findById(pushNotification.getId());
+            assertThat(actual).isEmpty();
+        }
+
+        @DisplayName("id로 찾지 못했을 때 예외를 발생시킨다.")
+        @Test
+        void notFound_exception() {
+            // then
+            assertThatThrownBy(() -> pushNotificationService.deleteById(0L))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("ExceptionData")
+                    .isEqualTo(ExceptionData.NOT_FOUND_PUSH_NOTIFICATION);
+        }
+    }
+
+    @DisplayName("한 멤버에 대해 보내진 알림을 삭제할 때 - deleteCompletedByMember()")
+    @Nested
+    class DeleteCompletedByMember {
+
+        @DisplayName("보낸 알림을 모두 삭제한다.")
+        @Test
+        void deleteByMember() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            Member member = fixture.회원_조회(조조그린_ID);
+
+            fixture.발송된_알림_생성(조조그린_ID, 1L, now.minusHours(2), PushCase.COMMENT);
+            fixture.발송된_알림_생성(조조그린_ID, 1L, now.minusHours(2), PushCase.CHALLENGE);
+
+            fixture.발송_예정_알림_생성(조조그린_ID, 1L, now.plusMinutes(2), PushCase.SUBSCRIPTION);
+            fixture.발송된_알림_생성(더즈_ID, 1L, now.plusMinutes(2), PushCase.SUBSCRIPTION);
+
+            // when
+            pushNotificationService.deleteCompletedByMember(member);
+
+            // then
+            assertThat(pushNotificationRepository.findAll()).hasSize(2);
+        }
     }
 }

--- a/backend/smody/src/test/java/com/woowacourse/smody/push/service/PushSubscriptionServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/push/service/PushSubscriptionServiceTest.java
@@ -1,0 +1,99 @@
+package com.woowacourse.smody.push.service;
+
+import static com.woowacourse.smody.support.ResourceFixture.더즈_ID;
+import static com.woowacourse.smody.support.ResourceFixture.조조그린_ID;
+import static com.woowacourse.smody.support.ResourceFixture.토닉_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.woowacourse.smody.member.domain.Member;
+import com.woowacourse.smody.push.domain.PushSubscription;
+import com.woowacourse.smody.support.IntegrationTest;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class PushSubscriptionServiceTest extends IntegrationTest {
+
+    @Autowired
+    private PushSubscriptionService pushSubscriptionService;
+
+    @DisplayName("endpoint로 알림 구독을 찾는다.")
+    @Test
+    void findByEndpoint() {
+        // given
+        fixture.알림_구독(조조그린_ID, "endpoint1");
+
+        // when
+        Optional<PushSubscription> actual = pushSubscriptionService.findByEndpoint("endpoint1");
+
+        // then
+        assertAll(
+                () -> assertThat(actual).isPresent(),
+                () -> assertThat(actual.get().getEndpoint()).isEqualTo("endpoint1")
+        );
+    }
+
+    @DisplayName("알림 구독을 생성한다.")
+    @Test
+    void create() {
+        // when
+        Member member = fixture.회원_조회(조조그린_ID);
+        pushSubscriptionService.create(
+                new PushSubscription("endpoint", "p256dh", "auth", member));
+
+        // then
+        assertThat(pushSubscriptionService.findByEndpoint("endpoint")).isPresent();
+    }
+
+    @DisplayName("알림을 삭제한다.")
+    @Test
+    void delete() {
+        // given
+        PushSubscription pushSubscription = fixture.알림_구독(조조그린_ID, "endpoint");
+
+        // when
+        pushSubscriptionService.delete(pushSubscription);
+
+        // then
+        assertThat(pushSubscriptionService.findByEndpoint("endpoint")).isEmpty();
+    }
+
+    @DisplayName("회원들의 알림 구독을 조회한다.")
+    @Test
+    void searchByMembers() {
+        // given
+        Member member1 = fixture.회원_조회(조조그린_ID);
+        Member member2 = fixture.회원_조회(토닉_ID);
+        Member member3 = fixture.회원_조회(더즈_ID);
+        fixture.알림_구독(조조그린_ID, "endpoint1");
+        fixture.알림_구독(토닉_ID, "endpoint2");
+        fixture.알림_구독(더즈_ID, "endpoint3");
+
+        // when
+        List<PushSubscription> pushSubscriptions = pushSubscriptionService.searchByMembers(
+                List.of(member1, member2, member3));
+
+        // then
+        assertAll(
+                () -> assertThat(pushSubscriptions).hasSize(3),
+                () -> assertThat(pushSubscriptions).map(pushSubscription -> pushSubscription.getMember().getId())
+                        .contains(조조그린_ID, 토닉_ID, 더즈_ID)
+        );
+    }
+
+    @DisplayName("endpoint에 해당하는 알림 구독을 삭제한다.")
+    @Test
+    void deleteByEndpoint() {
+        // given
+        fixture.알림_구독(조조그린_ID, "endpoint");
+
+        // when
+        pushSubscriptionService.deleteByEndpoint("endpoint");
+
+        // then
+        assertThat(pushSubscriptionService.findByEndpoint("endpoint")).isEmpty();
+    }
+}

--- a/backend/smody/src/test/java/com/woowacourse/smody/support/ControllerTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/support/ControllerTest.java
@@ -28,7 +28,7 @@ import com.woowacourse.smody.push.controller.PushNotificationController;
 import com.woowacourse.smody.push.controller.PushSubscriptionController;
 import com.woowacourse.smody.push.service.PushNotificationApiService;
 import com.woowacourse.smody.push.service.PushSubscriptionApiService;
-import com.woowacourse.smody.push.service.WebPushService;
+import com.woowacourse.smody.push.api.WebPushApi;
 import com.woowacourse.smody.ranking.controller.RankingController;
 import com.woowacourse.smody.ranking.service.RankingApiService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -105,7 +105,7 @@ public class ControllerTest {
     protected PushSubscriptionApiService pushSubscriptionApiService;
 
     @MockBean
-    protected WebPushService webPushService;
+    protected WebPushApi webPushApi;
 
     @MockBean
     protected PushNotificationApiService pushNotificationApiService;

--- a/backend/smody/src/test/java/com/woowacourse/smody/support/IntegrationTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/support/IntegrationTest.java
@@ -1,7 +1,7 @@
 package com.woowacourse.smody.support;
 
 import com.woowacourse.smody.image.strategy.ImageStrategy;
-import com.woowacourse.smody.push.service.WebPushService;
+import com.woowacourse.smody.push.api.WebPushApi;
 import com.woowacourse.smody.support.isoloation.SmodyTestEnvironmentExtension;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -20,7 +20,7 @@ public class IntegrationTest {
     protected ImageStrategy imageStrategy;
 
     @MockBean
-    protected WebPushService webPushService;
+    protected WebPushApi webPushApi;
 
     @MockBean
     protected RestTemplate restTemplate;


### PR DESCRIPTION
## 컨벤션
전체적으로 테스트에 대한 컨벤션을 아래와 같이 작성했습니다.
- 하나의 메서드에 테스트가 하나이면 테스트 메서드 이름을 동일하게 유지하고 작성한다.
- 테스트가 2개라면 Nested를 사용하여 class 이름을 테스트할 메서드 이름과 동일하게 유지하고 테스트 메서드는 케이스별로 작성한다.

## Challenge
<img width="693" alt="image" src="https://user-images.githubusercontent.com/59171113/196620589-6a0bd8f8-ba8e-487b-82ea-d7625293c4e5.png">
<img width="697" alt="image" src="https://user-images.githubusercontent.com/59171113/196620646-c226acd1-d10c-40f8-9ddb-8ba88377643c.png">

## Push
- deleteById 를 할 때 id를 찾지 못하는 경우 예외  처리
  - `ExceptionData.NOT_FOUND_PUSH_NOTIFICATION`

```java
@Transactional
public void deleteById(Long pushNotificationId) {
    try {
        pushNotificationRepository.deleteById(pushNotificationId);
    } catch (EmptyResultDataAccessException e) {
        throw new BusinessException(ExceptionData.NOT_FOUND_PUSH_NOTIFICATION);
    }
}
```

