### PR TITLE
refactor: (be) 챌린지 추천 로직, 예상치 못한 에러에 대한 처리 로직 변경

### DIFF
--- a/backend/smody/src/main/java/com/woowacourse/smody/challenge/controller/ChallengeController.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/challenge/controller/ChallengeController.java
@@ -43,10 +43,11 @@ public class ChallengeController {
     @RequiredLogin
     public ResponseEntity<List<ChallengeTabResponse>> findAllWithChallengerCountByFilter(
             @LoginMember TokenPayload tokenPayload,
-            @ModelAttribute PagingParams pagingParams) {
+            @ModelAttribute PagingParams pagingParams
+    ) {
         return ResponseEntity.ok(challengeApiService.findAllWithChallengerCountByFilter(
-                tokenPayload, LocalDateTime.now(), pagingParams)
-        );
+                tokenPayload, LocalDateTime.now(), pagingParams
+        ));
     }
 
     @GetMapping(value = "/me")

--- a/backend/smody/src/main/java/com/woowacourse/smody/challenge/repository/ChallengeRepository.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/challenge/repository/ChallengeRepository.java
@@ -1,10 +1,17 @@
 package com.woowacourse.smody.challenge.repository;
 
 import com.woowacourse.smody.challenge.domain.Challenge;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ChallengeRepository extends JpaRepository<Challenge, Long>, DynamicChallengeRepository {
 
     Optional<Challenge> findByName(String name);
+
+    @Query("select c.id from Challenge c")
+    List<Long> findAllIds();
+
+    List<Challenge> findAllByIdIn(List<Long> challengeIds);
 }

--- a/backend/smody/src/main/java/com/woowacourse/smody/challenge/service/ChallengeApiService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/challenge/service/ChallengeApiService.java
@@ -45,6 +45,9 @@ public class ChallengeApiService {
         if (pagingParams.getSort().equals("popular")) {
             return getChallengeTabResponsesWhenPopular(searchTime, pagingParams, member);
         }
+        if (pagingParams.getSort().equals("random")) {
+            return getChallengeTabResponsesWhenRandom(searchTime, pagingParams, member);
+        }
         List<Challenge> challenges = challengeService.findAllByFilter(pagingParams);
         List<Cycle> cycles = cycleService.findInProgressByChallenges(searchTime, challenges);
         ChallengingRecords challengingRecords = ChallengingRecords.from(cycles);
@@ -58,6 +61,15 @@ public class ChallengeApiService {
         ChallengingRecords challengingRecords = ChallengingRecords.from(cycles);
         List<Challenge> challenges = challengingRecords.getChallengesOrderByChallenger();
         List<Challenge> pagedChallenges = CursorPaging.apply(challenges, null, pagingParams.getSize());
+        return getChallengeTabResponses(pagedChallenges, member, challengingRecords);
+    }
+
+    private List<ChallengeTabResponse> getChallengeTabResponsesWhenRandom(final LocalDateTime searchTime,
+                                                                          final PagingParams pagingParams, final Member member) {
+        List<Challenge> randomChallenges = challengeService.findRandomChallenges(pagingParams.getSize());
+        List<Cycle> cycles = cycleService.findInProgress(searchTime);
+        ChallengingRecords challengingRecords = ChallengingRecords.from(cycles);
+        List<Challenge> pagedChallenges = CursorPaging.apply(randomChallenges, null, pagingParams.getSize());
         return getChallengeTabResponses(pagedChallenges, member, challengingRecords);
     }
 

--- a/backend/smody/src/main/java/com/woowacourse/smody/challenge/service/ChallengeService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/challenge/service/ChallengeService.java
@@ -5,6 +5,7 @@ import com.woowacourse.smody.challenge.repository.ChallengeRepository;
 import com.woowacourse.smody.db_support.PagingParams;
 import com.woowacourse.smody.exception.BusinessException;
 import com.woowacourse.smody.exception.ExceptionData;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -51,6 +52,20 @@ public class ChallengeService {
     private void validateDuplicatedName(String name) {
         if (challengeRepository.findByName(name).isPresent()) {
             throw new BusinessException(ExceptionData.DUPLICATE_NAME);
+        }
+    }
+
+    public List<Challenge> findRandomChallenges(Integer size) {
+        List<Long> allIds = challengeRepository.findAllIds();
+        validateSize(allIds, size);
+        Collections.shuffle(allIds);
+        List<Long> randomIds = allIds.subList(0, size);
+        return challengeRepository.findAllByIdIn(randomIds);
+    }
+
+    private void validateSize(List<Long> allIds, Integer size) {
+        if (allIds.size() < size) {
+            throw new BusinessException(ExceptionData.OUT_OF_BOUND_RANDOM_SIZE);
         }
     }
 }

--- a/backend/smody/src/main/java/com/woowacourse/smody/challenge/service/ChallengeService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/challenge/service/ChallengeService.java
@@ -57,15 +57,8 @@ public class ChallengeService {
 
     public List<Challenge> findRandomChallenges(Integer size) {
         List<Long> allIds = challengeRepository.findAllIds();
-        validateSize(allIds, size);
         Collections.shuffle(allIds);
-        List<Long> randomIds = allIds.subList(0, size);
+        List<Long> randomIds = allIds.subList(0, Math.min(size, allIds.size()));
         return challengeRepository.findAllByIdIn(randomIds);
-    }
-
-    private void validateSize(List<Long> allIds, Integer size) {
-        if (allIds.size() < size) {
-            throw new BusinessException(ExceptionData.OUT_OF_BOUND_RANDOM_SIZE);
-        }
     }
 }

--- a/backend/smody/src/main/java/com/woowacourse/smody/exception/ControllerAdvice.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/exception/ControllerAdvice.java
@@ -26,7 +26,7 @@ public class ControllerAdvice {
         ExceptionData exceptionData = businessException.getExceptionData();
         log.info("[비즈니스 예외 발생] 에러 코드 : {}, 메세지 : {}", exceptionData.getCode(), exceptionData.getMessage());
         if (exceptionData.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR.value()
-                && isProdProfile(environment.getActiveProfiles())) {
+                && isProdProfile()) {
             githubApi.create(businessException);
         }
         return ResponseEntity.status(exceptionData.getStatusCode())
@@ -36,15 +36,15 @@ public class ControllerAdvice {
     @ExceptionHandler
     public ResponseEntity<String> handleUnExpectedException(Exception exception) {
         log.error("[예상치 못한 예외 발생] ", exception);
-        if (isProdProfile(environment.getActiveProfiles())) {
+        if (isProdProfile()) {
             githubApi.create(exception);
         }
         return ResponseEntity.internalServerError()
                 .body(ExceptionUtils.createIssueBody(exception));
     }
 
-    private boolean isProdProfile(String[] activeProfiles) {
-        return Arrays.stream(activeProfiles)
+    private boolean isProdProfile() {
+        return Arrays.stream(environment.getActiveProfiles())
                 .anyMatch(env -> env.equalsIgnoreCase(ISSUE_CREATE_PROFILE));
     }
 }

--- a/backend/smody/src/main/java/com/woowacourse/smody/exception/ControllerAdvice.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/exception/ControllerAdvice.java
@@ -40,7 +40,7 @@ public class ControllerAdvice {
             githubApi.create(exception);
         }
         return ResponseEntity.internalServerError()
-                .body(ExceptionUtils.createIssueBody(exception));
+                .body(ExceptionUtils.extractStackTrace(exception));
     }
 
     private boolean isProdProfile() {

--- a/backend/smody/src/main/java/com/woowacourse/smody/exception/ExceptionData.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/exception/ExceptionData.java
@@ -29,6 +29,7 @@ public enum ExceptionData {
     NOT_FOUND_RANKING_PERIOD(4006, "존재하지 않는 랭킹 기간입니다.", 404),
     NOT_FOUND_RANKING_ACTIVITY(4007, "존재하지 않는 랭킹 활동입니다.", 404),
     NOT_FOUND_PUSH_NOTIFICATION(4008, "알림을 찾을 수 없습니다.", 404),
+    NOT_FOUND_SORT(4009, "정렬 기준을 찾을 수 없습니다.", 404),
 
     EMPTY_IMAGE(5001, "이미지의 바이트코드가 비었습니다.", 400),
 
@@ -38,14 +39,12 @@ public enum ExceptionData {
     DUPLICATE_NAME(7002, "중복된 챌린지 이름입니다.", 400),
     INVALID_CHALLENGE_NAME(7003, "챌린지 이름 형식이 올바르지 않습니다.", 400),
     INVALID_SEARCH_NAME(7004, "검색 이름 형식이 올바르지 않습니다.", 400),
-    ANY_PROGRESS_RECORD_CHALLENGE(7005, "인증 기록이 없는 챌린지입니다.", 400),
+    OUT_OF_BOUND_RANDOM_SIZE(7005, "랜덤 조회할 챌린지 개수가 전체 챌린지 개수보다 많습니다.", 400),
 
     WEB_PUSH_ERROR(8001, "웹 푸시 라이브러리 관련 예외입니다.", 400),
 
     AUTHORIZATION_SERVER_ERROR(9001, "인가 관련 서버 내부의 오류입니다.", 500),
-    IMAGE_UPLOAD_ERROR(9002, "이미지 업로드 관련 서버 내부의 오류입니다.", 500),
     DATA_INTEGRITY_ERROR(9003, "데이터 정합성 관련 서버 내부의 오류입니다.", 500),
-    NOT_FOUND_SORT(9004, "정렬 기준을 찾을 수 없습니다.", 500)
     ;
 
     private final int code;

--- a/backend/smody/src/main/java/com/woowacourse/smody/exception/ExceptionData.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/exception/ExceptionData.java
@@ -39,7 +39,6 @@ public enum ExceptionData {
     DUPLICATE_NAME(7002, "중복된 챌린지 이름입니다.", 400),
     INVALID_CHALLENGE_NAME(7003, "챌린지 이름 형식이 올바르지 않습니다.", 400),
     INVALID_SEARCH_NAME(7004, "검색 이름 형식이 올바르지 않습니다.", 400),
-    OUT_OF_BOUND_RANDOM_SIZE(7005, "랜덤 조회할 챌린지 개수가 전체 챌린지 개수보다 많습니다.", 400),
 
     WEB_PUSH_ERROR(8001, "웹 푸시 라이브러리 관련 예외입니다.", 400),
 

--- a/backend/smody/src/main/java/com/woowacourse/smody/exception/ExceptionUtils.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/exception/ExceptionUtils.java
@@ -5,9 +5,9 @@ import java.io.StringWriter;
 
 public class ExceptionUtils {
 
-    public static String createIssueBody(Exception exception) {
-        StringWriter issueBody = new StringWriter();
-        exception.printStackTrace(new PrintWriter(issueBody));
-        return String.valueOf(issueBody);
+    public static String extractStackTrace(Exception exception) {
+        StringWriter stackTrace = new StringWriter();
+        exception.printStackTrace(new PrintWriter(stackTrace));
+        return String.valueOf(stackTrace);
     }
 }

--- a/backend/smody/src/main/java/com/woowacourse/smody/exception/ExceptionUtils.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/exception/ExceptionUtils.java
@@ -1,0 +1,13 @@
+package com.woowacourse.smody.exception;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public class ExceptionUtils {
+
+    public static String createIssueBody(Exception exception) {
+        StringWriter issueBody = new StringWriter();
+        exception.printStackTrace(new PrintWriter(issueBody));
+        return String.valueOf(issueBody);
+    }
+}

--- a/backend/smody/src/main/java/com/woowacourse/smody/exception/api/GithubApi.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/exception/api/GithubApi.java
@@ -4,9 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.smody.exception.BusinessException;
 import com.woowacourse.smody.exception.ExceptionData;
+import com.woowacourse.smody.exception.ExceptionUtils;
 import com.woowacourse.smody.exception.dto.IssueCreateRequest;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -44,7 +43,7 @@ public class GithubApi {
     private String createRequestJson(Exception exception) {
         return parseJsonString(new IssueCreateRequest(
                 "[ERROR] 서버 장애 발생 " + exception.getMessage(),
-                createIssueBody(exception),
+                "```\n" + ExceptionUtils.createIssueBody(exception) + "\n```",
                 ASSIGNEES,
                 LABELS
         ));
@@ -56,12 +55,6 @@ public class GithubApi {
         } catch (JsonProcessingException e) {
             throw new BusinessException(ExceptionData.DATA_INTEGRITY_ERROR);
         }
-    }
-
-    private String createIssueBody(Exception exception) {
-        StringWriter stringWriter = new StringWriter();
-        exception.printStackTrace(new PrintWriter(stringWriter));
-        return "```\n" + stringWriter + "\n```";
     }
 
     private HttpHeaders setAuthorization() {

--- a/backend/smody/src/main/java/com/woowacourse/smody/exception/api/GithubApi.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/exception/api/GithubApi.java
@@ -43,7 +43,7 @@ public class GithubApi {
     private String createRequestJson(Exception exception) {
         return parseJsonString(new IssueCreateRequest(
                 "[ERROR] 서버 장애 발생 " + exception.getMessage(),
-                "```\n" + ExceptionUtils.createIssueBody(exception) + "\n```",
+                "```\n" + ExceptionUtils.extractStackTrace(exception) + "\n```",
                 ASSIGNEES,
                 LABELS
         ));


### PR DESCRIPTION
### 문제 상황과 해결 방법

- mysql 에서는 기존 무작위 챌린지를 조회하던 쿼리가 실행되지 않았던 문제
  - 모든 챌린지들의 아이디를 조회해서 정해진 만큼 무작위로 고른 다음 해당 챌린지들을 다시 조회하는 방식으로 무작위를 구현하였다.
- 예상치 못한 에러가 발생했을 때 http response 로 200 ok 를 응답하는 문제
  - 예상치 못한 에러가 발생했을 때 깃허브 이슈로 해당 에러를 등록한 뒤 500 에러와 함께 해당 에러 로그를 response body 에 담아서 응답하도록 로직을 변경하였다.