### PR TITLE
feat: (fe) feedItem이 피드 상세 페이지일 경우 이미지 높이를 100%로 변경하여 모두 보기

### DIFF
--- a/frontend/src/components/@shared/ModalOverlay/index.tsx
+++ b/frontend/src/components/@shared/ModalOverlay/index.tsx
@@ -1,4 +1,4 @@
-import { ModalOverlayProps } from './type';
+import { ModalOverlayProps, ModalProps } from './type';
 import { PropsWithChildren } from 'react';
 import ReactDOM from 'react-dom';
 import styled, { css } from 'styled-components';
@@ -8,31 +8,43 @@ import { Z_INDEX } from 'constants/css';
 export const ModalOverlay = ({
   children,
   handleCloseModal,
+  isFullSize = false,
 }: PropsWithChildren<ModalOverlayProps>) => {
   return (
     <>
       {ReactDOM.createPortal(
-        <Backdrop onClick={handleCloseModal} />,
+        <Backdrop onClick={handleCloseModal} isFullSize={isFullSize} />,
         document.getElementById('backdrop-root') as HTMLElement,
       )}
       {ReactDOM.createPortal(
-        <Modal>{children}</Modal>,
+        <Modal isFullSize={isFullSize}>{children}</Modal>,
         document.getElementById('overlay-root') as HTMLElement,
       )}
     </>
   );
 };
 
-const Modal = styled.div`
-  ${({ theme }) => css`
-    min-height: 347px;
-    width: 366px;
+const Modal = styled.div<ModalProps>`
+  ${({ theme, isFullSize }) => css`
+    ${isFullSize
+      ? css`
+          max-height: 90vh;
+          max-width: 90vw;
+          background-color: transparent;
+          backdrop-filter: blur(3px);
+        `
+      : css`
+          min-height: 347px;
+          width: 366px;
+          max-width: 90vw;
+          background-color: ${theme.surface};
+        `}
+
     position: fixed;
     top: 50%;
     left: 50%;
     transform: translateX(-50%) translateY(-50%);
     margin: 0;
-    background-color: ${theme.surface};
     border-radius: 20px;
     display: flex;
     justify-content: center;
@@ -40,8 +52,13 @@ const Modal = styled.div`
   `}
 `;
 
-const Backdrop = styled.div`
-  ${({ theme }) => css`
+const Backdrop = styled.div<ModalProps>`
+  ${({ theme, isFullSize }) => css`
+    ${isFullSize &&
+    css`
+      backdrop-filter: blur(3px);
+    `}
+
     position: fixed;
     top: 0;
     left: 0;

--- a/frontend/src/components/@shared/ModalOverlay/type.ts
+++ b/frontend/src/components/@shared/ModalOverlay/type.ts
@@ -1,3 +1,8 @@
 export type ModalOverlayProps = {
   handleCloseModal(): void;
+  isFullSize?: boolean;
+};
+
+export type ModalProps = {
+  isFullSize: boolean;
 };

--- a/frontend/src/components/FeedItem/index.tsx
+++ b/frontend/src/components/FeedItem/index.tsx
@@ -86,6 +86,7 @@ export const FeedItem = ({
         src={progressImage}
         alt={`${nickname}님의 ${challengeName} 인증 사진`}
         isSuccess={isSuccess}
+        isDetailPage={isDetailPage}
       />
       <Text size={14} color={themeContext.mainText}>
         {`${year}.${month}.${date} ${hours}:${minutes}`}
@@ -133,11 +134,11 @@ const ChallengeName = styled(UnderLineText)`
   pointer-events: auto;
 `;
 
-const ProgressImg = styled.img<CheckSuccessProps>`
-  ${({ theme, isSuccess }) => css`
+const ProgressImg = styled.img<CheckSuccessProps & WrapperProps>`
+  ${({ theme, isSuccess, isDetailPage }) => css`
     width: 100%;
-    height: 400px;
-    object-fit: cover;
+    height: ${isDetailPage ? '100%' : '400px'};
+    object-fit: ${isDetailPage ? 'scale-down' : 'cover'};
     border-radius: 20px;
     background-color: white;
     margin: 0.2rem 0.1rem;

--- a/frontend/src/components/FeedItem/index.tsx
+++ b/frontend/src/components/FeedItem/index.tsx
@@ -138,7 +138,7 @@ const ProgressImg = styled.img<CheckSuccessProps & WrapperProps>`
   ${({ theme, isSuccess, isDetailPage }) => css`
     width: 100%;
     height: ${isDetailPage ? '100%' : '400px'};
-    object-fit: ${isDetailPage ? 'scale-down' : 'cover'};
+    object-fit: cover;
     border-radius: 20px;
     background-color: white;
     margin: 0.2rem 0.1rem;

--- a/frontend/src/components/FeedItem/index.tsx
+++ b/frontend/src/components/FeedItem/index.tsx
@@ -1,5 +1,12 @@
-import { CheckSuccessProps, FeedItemProps, WrapperProps } from './type';
+import {
+  CheckSuccessProps,
+  FeedItemProps,
+  ImgCloseButtonProps,
+  WrapperProps,
+} from './type';
 import useFeedItem from './useFeedItem';
+import { useState } from 'react';
+import { AiFillCloseCircle } from 'react-icons/ai';
 import styled, { css } from 'styled-components';
 
 import useThemeContext from 'hooks/useThemeContext';
@@ -10,7 +17,10 @@ import {
   UnderLineText,
   CheckCircles,
   CheckSuccessCycle,
+  ModalOverlay,
 } from 'components';
+
+import COLOR from 'styles/color';
 
 export const FeedItem = ({
   cycleDetailId,
@@ -47,11 +57,21 @@ export const FeedItem = ({
     isShowBriefChallengeName,
   });
 
+  const [isImgModalOpen, setIsImgModalOpen] = useState(false);
+
+  const handleCloseImgModal = () => {
+    setIsImgModalOpen(false);
+  };
+
+  const handleOpenImgModal = () => {
+    setIsImgModalOpen(true);
+  };
+
   return (
     <Wrapper
       flexDirection="column"
       gap="0.4rem"
-      onClick={handleClickFeed}
+      onClick={isDetailPage ? undefined : handleClickFeed}
       isDetailPage={isDetailPage}
     >
       <FlexBox alignItems="center" flexWrap="wrap">
@@ -62,6 +82,7 @@ export const FeedItem = ({
           width="32px"
           height="32px"
         />
+
         <Nickname size={20} color={themeContext.onBackground}>
           {nickname}
         </Nickname>
@@ -77,6 +98,7 @@ export const FeedItem = ({
         >
           {renderedChallengeName}
         </ChallengeName>
+
         <CheckSuccessCycle isSuccess={isSuccess} />
       </FlexBox>
       <CheckCirclesWrapper justifyContent="flex-end">
@@ -86,7 +108,7 @@ export const FeedItem = ({
         src={progressImage}
         alt={`${nickname}님의 ${challengeName} 인증 사진`}
         isSuccess={isSuccess}
-        isDetailPage={isDetailPage}
+        onClick={isDetailPage ? handleOpenImgModal : undefined}
       />
       <Text size={14} color={themeContext.mainText}>
         {`${year}.${month}.${date} ${hours}:${minutes}`}
@@ -97,7 +119,30 @@ export const FeedItem = ({
       <CommentCount size={14} color={themeContext.mainText}>
         {`댓글 ${commentCount}개`}
       </CommentCount>
+      {isImgModalOpen && (
+        <ModalOverlay handleCloseModal={handleCloseImgModal} isFullSize={true}>
+          <div>
+            <ImgCloseButton handleCloseImgModal={handleCloseImgModal} />
+            <EntireImg
+              src={progressImage}
+              alt={`${nickname}님의 ${challengeName} 인증 사진`}
+            />
+          </div>
+        </ModalOverlay>
+      )}
     </Wrapper>
+  );
+};
+
+const ImgCloseButton = ({ handleCloseImgModal }: ImgCloseButtonProps) => {
+  return (
+    <CloseButton type="button" onClick={handleCloseImgModal} aria-label="닫기">
+      <BackWhite>
+        <CloseCircleWrapper>
+          <AiFillCloseCircle color={COLOR.PURPLE} size={30} />
+        </CloseCircleWrapper>
+      </BackWhite>
+    </CloseButton>
   );
 };
 
@@ -106,8 +151,10 @@ const Wrapper = styled(FlexBox)<WrapperProps>`
     max-width: 440px;
     min-width: 366px;
     padding: 20px 0;
-    cursor: pointer;
-    pointer-events: ${isDetailPage ? 'none' : 'auto'};
+    ${!isDetailPage &&
+    css`
+      cursor: pointer;
+    `}
 
     @media all and (max-width: 366px) {
       min-width: auto;
@@ -131,13 +178,13 @@ const OfText = styled(Text)`
 `;
 
 const ChallengeName = styled(UnderLineText)`
-  pointer-events: auto;
+  cursor: pointer;
 `;
 
-const ProgressImg = styled.img<CheckSuccessProps & WrapperProps>`
-  ${({ theme, isSuccess, isDetailPage }) => css`
+const ProgressImg = styled.img<CheckSuccessProps>`
+  ${({ theme, isSuccess }) => css`
     width: 100%;
-    height: ${isDetailPage ? '100%' : '400px'};
+    height: 400px;
     object-fit: cover;
     border-radius: 20px;
     background-color: white;
@@ -166,4 +213,33 @@ const CommentCount = styled(Text)`
 
 const CheckCirclesWrapper = styled(FlexBox)`
   flex-grow: 1;
+`;
+
+const EntireImg = styled.img`
+  max-height: 90vh;
+  max-width: 90vw;
+  object-fit: contain;
+`;
+
+const CloseButton = styled.button`
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin: 4px;
+  text-align: end;
+`;
+
+const BackWhite = styled.div`
+  position: relative;
+  margin: 10px;
+  background: #fff;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+`;
+
+const CloseCircleWrapper = styled.div`
+  position: absolute;
+  top: -7px;
+  right: -7px;
 `;

--- a/frontend/src/components/FeedItem/type.ts
+++ b/frontend/src/components/FeedItem/type.ts
@@ -20,3 +20,5 @@ export type WrapperProps = Pick<FeedItemProps, 'isDetailPage'>;
 export type CheckSuccessProps = {
   isSuccess: boolean;
 };
+
+export type ImgCloseButtonProps = { handleCloseImgModal: () => void };

--- a/frontend/src/mocks/data.ts
+++ b/frontend/src/mocks/data.ts
@@ -827,7 +827,8 @@ export const feedData = [
     picture:
       'https://cdn.pixabay.com/photo/2022/08/03/04/41/beech-leaves-7361863_1280.jpg',
     nickname: '유저1',
-    progressImage: 'https://i.ibb.co/mJwjFq1/progress-Image.png',
+    progressImage:
+      'https://images.smody.co.kr/images/ea30c87c-eedb-467c-9910-b9230ec65e58.jpg',
     progressCount: 1,
     description:
       '바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^바다가 너무 예쁘네요^_^',


### PR DESCRIPTION
## before
- 문제점: 현재 이미지를 정사각형으로 보여주어 정사각형 나머지 영역은 화면에 보이지 않음. 특히 세로로 매우 긴 이미지를 올리는 사용자들이 늘어남에 따라 관련 컴플레인 예상

<img width="498" alt="스크린샷 2022-10-20 오전 1 05 18" src="https://user-images.githubusercontent.com/59413128/196745224-43f37ed0-c714-4331-80a9-d098c6a98074.png">

## after
- 해결: 피드 상세보기 페이지에서만 height를 100%로 변경하여 세로로 긴 이미지를 올리는 경우에 대응, 피드 모아보기 페이지에는 영향 없음
<img width="641" alt="스크린샷 2022-10-20 오전 1 05 34" src="https://user-images.githubusercontent.com/59413128/196745256-cec0b3d3-a95c-4f4f-bbe7-0f7ee3915f86.png">
<img width="636" alt="스크린샷 2022-10-20 오전 1 05 43" src="https://user-images.githubusercontent.com/59413128/196745277-a99915f1-f5ff-4619-9d32-9198b8d58675.png">

