### PR TITLE
feat: (fe) 탭과 알림 모두 삭제에서 refetch가 안되는 에러

### DIFF
--- a/frontend/public/pwaServiceWorker.js
+++ b/frontend/public/pwaServiceWorker.js
@@ -1,4 +1,4 @@
-const VERSION = 'v5.1.0';
+const VERSION = 'v5.1.1';
 const CACHE_NAME = 'smody-cache_' + VERSION;
 const IMAGE_CACHE_NAME = 'smody-image_' + VERSION;
 

--- a/frontend/src/apis/challengeApi/index.ts
+++ b/frontend/src/apis/challengeApi/index.ts
@@ -41,7 +41,7 @@ export const useGetAllChallenges = (
   >,
 ) =>
   useInfiniteQuery<AxiosResponse<GetAllChallengesResponse>, AxiosError<ErrorResponse>>(
-    queryKeys.getAllChallenges,
+    [queryKeys.getAllChallenges, sort],
     localStorage.getItem('accessToken')
       ? ({ pageParam = 0 }) =>
           getAllChallengesAuth({ searchValue, sort, cursorId: pageParam })

--- a/frontend/src/components/SubscriptionButton/useSubscriptionButton.ts
+++ b/frontend/src/components/SubscriptionButton/useSubscriptionButton.ts
@@ -1,16 +1,23 @@
 import { UseSubscriptionButtonProps } from './type';
 import { useDeleteAllNotification } from 'apis';
+import { queryKeys } from 'apis/constants';
 import { pushStatus } from 'pwa/pushStatus';
 import { useEffect } from 'react';
+import { useQueryClient } from 'react-query';
 
 import useSubscribe from 'hooks/useSubscribe';
 
 export const useSubscriptionButton = ({
   updateIsSubscribed,
 }: UseSubscriptionButtonProps) => {
+  const queryClient = useQueryClient();
   const { isSubscribed, subscribe, isLoadingSubscribe } = useSubscribe();
   const { mutate: deleteAllNotifications, isLoading: isLoadingDeleteAllNotifications } =
-    useDeleteAllNotification();
+    useDeleteAllNotification({
+      onSuccess: () => {
+        queryClient.invalidateQueries(queryKeys.getNotifications);
+      },
+    });
 
   useEffect(() => {
     updateIsSubscribed(isSubscribed);

--- a/frontend/src/mocks/handlers/challenge.js
+++ b/frontend/src/mocks/handlers/challenge.js
@@ -81,6 +81,15 @@ export const challenge = [
   // 5. 모든 챌린지 조회(GET) - 비회원
   rest.get(`${BASE_URL}/challenges`, (req, res, ctx) => {
     const searchValue = req.url.searchParams.get('filter');
+    const sort = req.url.searchParams.get('sort');
+
+    if (sort === 'popular') {
+      return res(ctx.status(200), ctx.json(challengeData.splice(0, 1)));
+    }
+    if (sort === 'random') {
+      return res(ctx.status(200), ctx.json(challengeData.splice(0, 5)));
+    }
+
     if (searchValue === null) {
       return res(ctx.status(200), ctx.json(challengeData));
     }
@@ -88,6 +97,7 @@ export const challenge = [
     const filteredData = challengeData.filter((challenge) =>
       challenge.challengeName.includes(searchValue),
     );
+
     return res(ctx.status(200), ctx.json(filteredData));
   }),
   // 5. 모든 챌린지 조회(GET) - 회원
@@ -97,6 +107,15 @@ export const challenge = [
     }
 
     const searchValue = req.url.searchParams.get('filter');
+    const sort = req.url.searchParams.get('sort');
+
+    if (sort === 'popular') {
+      return res(ctx.status(200), ctx.json(challengeData.splice(0, 1)));
+    }
+    if (sort === 'random') {
+      return res(ctx.status(200), ctx.json(challengeData.splice(0, 5)));
+    }
+
     if (searchValue === null) {
       return res(ctx.status(200), ctx.json(challengeData));
     }

--- a/frontend/src/pages/ChallengePage/index.tsx
+++ b/frontend/src/pages/ChallengePage/index.tsx
@@ -12,19 +12,19 @@ import { CLIENT_PATH } from 'constants/path';
 const tabList = [
   {
     path: CLIENT_PATH.CHALLENGE_EVENT,
-    tabName: '[우테코]이벤트',
+    tabName: '⭐ [우테코]이벤트',
   },
   {
     path: CLIENT_PATH.CHALLENGE_POPULAR,
-    tabName: '인기',
+    tabName: '🔥 인기',
   },
   {
     path: CLIENT_PATH.CHALLENGE_RANDOM,
-    tabName: '추천',
+    tabName: '🎲 추천',
   },
   {
     path: CLIENT_PATH.CHALLENGE_SEARCH,
-    tabName: '전체검색',
+    tabName: '🔎 전체검색',
   },
 ];
 

--- a/frontend/src/pages/RandomChallengePage/index.tsx
+++ b/frontend/src/pages/RandomChallengePage/index.tsx
@@ -38,7 +38,7 @@ const RandomChallengePage = () => {
   return (
     <FlexBox flexDirection="column">
       <TitleText color={themeContext.onBackground} size={20} fontWeight="bold">
-        ❔ 이런 챌린지는 어때요 ❔
+        🎲 이런 챌린지는 어때요 🎲
       </TitleText>
       <ChallengeList challengeInfiniteData={challengeInfiniteData.pages} />
     </FlexBox>


### PR DESCRIPTION
- [x] 정렬 기준에 따라 다른 query key로 구현
- [x] 알림 삭제를 눌렀을 때 onSuccess에서 notification messages refetch
- [x] 추가적으로 탭 디자인 수정
  - ![image](https://user-images.githubusercontent.com/70249108/196862306-956557de-77de-4757-b22a-2ad1bf86eb32.png)
