### PR TITLE
feature: (fe) 웹 접근성 추가 개선

### DIFF
--- a/frontend/src/components/CheckCircles/index.tsx
+++ b/frontend/src/components/CheckCircles/index.tsx
@@ -11,12 +11,7 @@ export const CheckCircles = ({ progressCount }: CheckCirclesProps) => {
   return (
     <FlexBox gap="1rem" role="group" aria-label={`${progressCount}번 인증완료`}>
       {totalCheck.map((_, index) => (
-        <CheckCircle
-          key={index}
-          checkCircleCount={index}
-          progressCount={progressCount}
-          aria-hidden={true}
-        />
+        <CheckCircle key={index} checkCircleCount={index} progressCount={progressCount} />
       ))}
     </FlexBox>
   );

--- a/frontend/src/components/CheckCircles/index.tsx
+++ b/frontend/src/components/CheckCircles/index.tsx
@@ -9,7 +9,7 @@ const totalCheck = [...Array(3)];
 
 export const CheckCircles = ({ progressCount }: CheckCirclesProps) => {
   return (
-    <FlexBox gap="1rem" aria-label={`${progressCount}번 인증완료`}>
+    <FlexBox gap="1rem" role="group" aria-label={`${progressCount}번 인증완료`}>
       {totalCheck.map((_, index) => (
         <CheckCircle
           key={index}

--- a/frontend/src/components/DarkModeButton/index.tsx
+++ b/frontend/src/components/DarkModeButton/index.tsx
@@ -3,14 +3,14 @@ import styled from 'styled-components';
 
 export const DarkModeButton = ({ checked, handleChange }: DarkModeButtonProps) => {
   return (
-    <CheckBoxWrapper aria-label="다크모드 전환 버튼">
+    <CheckBoxWrapper>
       <CheckBox
         id="darkModeCheckbox"
         type="checkbox"
         checked={checked}
         onChange={handleChange}
       />
-      <CheckBoxLabel htmlFor="darkModeCheckbox" />
+      <CheckBoxLabel htmlFor="darkModeCheckbox" aria-label="다크모드 전환 버튼" />
     </CheckBoxWrapper>
   );
 };

--- a/frontend/src/components/Input/index.tsx
+++ b/frontend/src/components/Input/index.tsx
@@ -2,7 +2,7 @@ import styled, { css } from 'styled-components';
 
 import { FlexBox } from 'components/@shared/FlexBox';
 
-import { InputProps, InputContainerProps, WordLengthProps } from 'components/Input/type';
+import { InputProps, InputContainerProps } from 'components/Input/type';
 import { useInput } from 'components/Input/useInput';
 import { ValidationMessage } from 'components/ValidationMessage';
 
@@ -52,9 +52,7 @@ export const Input = ({
         <div>
           <ValidationMessage isValidated={isValidated} value={value} message={message} />
         </div>
-        <WordLength isMargin={!!needWordLength}>
-          {needWordLength ? `${value?.length}/${maxLength}` : ''}
-        </WordLength>
+        {needWordLength && <WordLength>{`${value?.length}/${maxLength}`}</WordLength>}
       </FlexBox>
     </Wrapper>
   );
@@ -130,11 +128,6 @@ const TextAreaElement = styled.textarea`
   `}
 `;
 
-const WordLength = styled.div<WordLengthProps>`
-  ${({ isMargin }) => css`
-    ${isMargin &&
-    css`
-      margin-top: 0.3rem;
-    `}
-  `}
+const WordLength = styled.span`
+  margin-top: 0.3rem;
 `;

--- a/frontend/src/components/Input/type.ts
+++ b/frontend/src/components/Input/type.ts
@@ -17,7 +17,3 @@ export type InputProps = {
 export type InputContainerProps = Pick<InputProps, 'isValidated'> & {
   isFocus: boolean;
 };
-
-export type WordLengthProps = {
-  isMargin: boolean;
-};

--- a/frontend/src/components/Navbar/index.tsx
+++ b/frontend/src/components/Navbar/index.tsx
@@ -17,8 +17,8 @@ export const Navbar = () => {
   const { certColor, challengeColor, feedColor, profileColor, rankColor } = useNavBar();
 
   return (
-    <Footer>
-      <nav>
+    <Footer aria-label="하단 내브바">
+      <nav aria-label="하단 내브바 링크 목록">
         <NavItemsContainer justifyContent="space-around" alignItems="center" as="ul">
           <li>
             <NavLink
@@ -29,7 +29,7 @@ export const Navbar = () => {
               to={CLIENT_PATH.CHALLENGE_EVENT}
             >
               <ImFire size={23} color={challengeColor} />
-              <Text size={11} color={challengeColor}>
+              <Text size={11} color={challengeColor} aria-label="챌린지 탭">
                 챌린지
               </Text>
             </NavLink>
@@ -44,7 +44,7 @@ export const Navbar = () => {
               fill={feedColor}
             >
               <Feed />
-              <Text size={11} color={feedColor}>
+              <Text size={11} color={feedColor} aria-label="피드 탭">
                 피드
               </Text>
             </NavLink>
@@ -59,7 +59,7 @@ export const Navbar = () => {
               fill={certColor}
             >
               <Plus />
-              <Text size={11} color={certColor}>
+              <Text size={11} color={certColor} aria-label="인증 탭">
                 인증
               </Text>
             </NavLink>
@@ -73,7 +73,7 @@ export const Navbar = () => {
               to={CLIENT_PATH.RANK}
             >
               <BsTrophyFill size={23} color={rankColor} />
-              <Text size={11} color={rankColor}>
+              <Text size={11} color={rankColor} aria-label="랭킹 탭">
                 랭킹
               </Text>
             </NavLink>
@@ -88,7 +88,7 @@ export const Navbar = () => {
               fill={profileColor}
             >
               <Profile />
-              <Text size={11} color={profileColor}>
+              <Text size={11} color={profileColor} aria-label="프로필 탭">
                 프로필
               </Text>
             </NavLink>

--- a/frontend/src/components/SROnly/index.tsx
+++ b/frontend/src/components/SROnly/index.tsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export const SROnly = styled.p`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+`;

--- a/frontend/src/components/SuccessModal/index.tsx
+++ b/frontend/src/components/SuccessModal/index.tsx
@@ -49,6 +49,9 @@ export const SuccessModal = ({
         alignItems="center"
         justifyContent="center"
         gap="1rem"
+        role="dialog"
+        aria-label="인증 성공 모달"
+        tabIndex={0}
       >
         <CloseButton onClick={handleClickClose} aria-label="닫기">
           <Close />
@@ -93,7 +96,7 @@ export const SuccessModal = ({
             </RetryButton>
           </FlexBox>
         ) : (
-          <Button autoFocus onClick={handleClickCheck} size="medium" isActive={false}>
+          <Button onClick={handleClickCheck} size="medium" isActive={false}>
             기록 확인
           </Button>
         )}

--- a/frontend/src/components/Tabs/index.tsx
+++ b/frontend/src/components/Tabs/index.tsx
@@ -6,11 +6,11 @@ import { FlexBox } from 'components';
 
 import COLOR from 'styles/color';
 
-export const Tabs = ({ tabList }: TabsProps) => {
+export const Tabs = ({ tabList, ariaLabel }: TabsProps) => {
   const { pathname, handleClickTab } = useTabs();
 
   return (
-    <TabList as="ul" alignItems="center">
+    <TabList as="ul" alignItems="center" aria-label={ariaLabel}>
       {tabList.map(({ path, tabName }) => (
         <Tab
           key={path}

--- a/frontend/src/components/Tabs/type.ts
+++ b/frontend/src/components/Tabs/type.ts
@@ -4,6 +4,7 @@ type TabType = { path: string; tabName: string };
 
 export type TabsProps = {
   tabList: TabType[];
+  ariaLabel?: string;
 };
 
 export type TabProps = {

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -65,3 +65,4 @@ export * from 'components/CheckSuccessCycle';
 export * from 'components/Tabs';
 export * from 'components/Tooltip';
 export * from 'components/InstallPrompt';
+export * from 'components/SROnly';

--- a/frontend/src/pages/ChallengePage/index.tsx
+++ b/frontend/src/pages/ChallengePage/index.tsx
@@ -32,8 +32,8 @@ const ChallengePage = () => {
   const { handleCreateChallengeButton } = useChallengePage();
   return (
     <FlexBox flexDirection="column">
-      <Tabs tabList={tabList} />
-      <ContentWrapper>
+      <Tabs tabList={tabList} ariaLabel="챌린지 페이지 탭 목록" />
+      <ContentWrapper aria-label="탭 컨텐츠">
         <Suspense fallback={<LoadingSpinner />}>
           <ContentPage />
         </Suspense>

--- a/frontend/src/pages/EventPage/index.tsx
+++ b/frontend/src/pages/EventPage/index.tsx
@@ -11,8 +11,13 @@ const EventPage = () => {
   const themeContext = useThemeContext();
 
   return (
-    <FlexBox flexDirection="column" justifyContent="center">
-      <TitleText color={themeContext.onBackground} size={20} fontWeight="bold">
+    <FlexBox
+      flexDirection="column"
+      justifyContent="center"
+      aria-label="이벤트 챌린지 페이지"
+      as="section"
+    >
+      <TitleText color={themeContext.onBackground} size={20} fontWeight="bold" as="h1">
         ⭐ 우테코 팀프로젝트 사용 챌린지 이벤트 ⭐
       </TitleText>
       <DescriptionText color={themeContext.onBackground} size={16}>

--- a/frontend/src/pages/FeedPage/index.tsx
+++ b/frontend/src/pages/FeedPage/index.tsx
@@ -50,7 +50,7 @@ const FeedPage = () => {
       isFetching={isFetching}
       loader={<LoadingSpinner />}
     >
-      <FeedContainer as="ul">
+      <FeedContainer as="ul" aria-label="피드 목록">
         {feedInfiniteData?.pages.map((page) =>
           page?.data.map((feedInfo) => (
             <li key={feedInfo.cycleDetailId}>

--- a/frontend/src/pages/PopularChallengePage/index.tsx
+++ b/frontend/src/pages/PopularChallengePage/index.tsx
@@ -36,8 +36,8 @@ const PopularChallengePage = () => {
   }
 
   return (
-    <FlexBox flexDirection="column">
-      <TitleText color={themeContext.onBackground} size={20} fontWeight="bold">
+    <FlexBox flexDirection="column" aria-label="인기 챌린지 페이지" as="section">
+      <TitleText color={themeContext.onBackground} size={20} fontWeight="bold" as="h1">
         🔥 가장 많이 참여하고 있는 챌린지 🔥
       </TitleText>
       <ChallengeList challengeInfiniteData={challengeInfiniteData.pages} />

--- a/frontend/src/pages/RandomChallengePage/index.tsx
+++ b/frontend/src/pages/RandomChallengePage/index.tsx
@@ -36,8 +36,8 @@ const RandomChallengePage = () => {
   }
 
   return (
-    <FlexBox flexDirection="column">
-      <TitleText color={themeContext.onBackground} size={20} fontWeight="bold">
+    <FlexBox flexDirection="column" aria-label="랜덤 챌린지 페이지" as="section">
+      <TitleText color={themeContext.onBackground} size={20} fontWeight="bold" as="h1">
         🎲 이런 챌린지는 어때요 🎲
       </TitleText>
       <ChallengeList challengeInfiniteData={challengeInfiniteData.pages} />

--- a/frontend/src/pages/SearchPage/index.tsx
+++ b/frontend/src/pages/SearchPage/index.tsx
@@ -11,6 +11,7 @@ import {
   SearchBar,
   ChallengeList,
   ChallengeItem,
+  SROnly,
 } from 'components';
 
 const SearchPage = () => {
@@ -54,7 +55,12 @@ const SearchPage = () => {
   }
 
   return (
-    <SearchContentWrapper flexDirection="column">
+    <SearchContentWrapper
+      flexDirection="column"
+      aria-label="챌린지 검색 페이지"
+      as="section"
+    >
+      <SROnly as="h1">챌린지를 검색할 수 있습니다.</SROnly>
       <SearchBar
         searchInput={searchInput}
         handleChangeSearch={handleChangeSearch}


### PR DESCRIPTION
# 웹 접근성 추가 개선
## Lighthouse의 접근성 점수 개선 사항
DarkModeButton 버튼과 CheckCircles 컴포넌트에서 
`[aria-*] attributes do not match their roles` 문제가 발생했다.

해당 문제는 요소에 적용된 role에 부적절한 aria-* 속성을 사용할 때 발생하는 문제이다.

해당 문제를 해결하기 위한 해결 방법은 다음과 같다.
1. 부적절한 aria-* 속성 제거
2. 태그의 role 수정

## 내브바의 접근성 개선
내브바를 스크린리더로 읽을 때 `바닥글`이라고만 읽어주는 문제가 있었다. 또한 스크린리더의 내브바 내부의 각 탭 버튼 또한 적절히 읽어주지 않았다. aria-label 속성을 적절하게 사용해서 해당 문제를 해결했다.

## 페이지 포커스 시 내용을 전부 읽어주는 문제 해결
스크린리더로 챌린지 페이지의 내용(Layout 컴포넌트의 Outlet 부분)을 포커스했을 때, 해당 페이지의 컨텐츠를 전부 읽어주는 문제가 발생했다.
<img width="432" alt="image" src="https://user-images.githubusercontent.com/52148907/198957890-50eec040-3096-4102-8d91-fd25ec445118.png">

따라서 aria-label을 적절히 사용해서 해당 문제를 해결했다.
또한 챌린지 페이지의 각 탭 페이지(ex. PopularChallengePage)에 section 태그와 h1 태그를 적용하여 웹 표준을 준수하도록 했다.

## 인증 후 성공 모달이 포커스 안되는 문제 해결
기존에 모달 컴포넌트에 포커스 하기 위해 focus() 메서드를 사용했다.
하지만, 다시 테스트를 수행한 결과 해당 기능이 동작하지 않은 게 확인됐다.
따라서 focus() 메서드와 함께 tabIndex 속성을 함께 사용해서 문제를 해결했다.
