### PR TITLE
feat: (be) 사이클 진척도 증가시 cycleDetailId 추가

### DIFF
--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/dto/ProgressResponse.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/dto/ProgressResponse.java
@@ -1,6 +1,7 @@
 package com.woowacourse.smody.cycle.dto;
 
-import com.woowacourse.smody.cycle.domain.Progress;
+import com.woowacourse.smody.cycle.domain.Cycle;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,8 +12,10 @@ import lombok.NoArgsConstructor;
 public class ProgressResponse {
 
     private Integer progressCount;
+    private Long cycleDetailId;
 
-    public ProgressResponse(Progress progress) {
-        this.progressCount = progress.getCount();
+    public ProgressResponse(Cycle cycle) {
+        this.progressCount = cycle.getProgress().getCount();
+        this.cycleDetailId = cycle.getLatestCycleDetail().getId();
     }
 }

--- a/backend/smody/src/main/resources/static/docs/api.html
+++ b/backend/smody/src/main/resources/static/docs/api.html
@@ -537,7 +537,7 @@ Host: www.smody.co.kr</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /challenges/auth?size=10&amp;cursorId=7 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzE1LCJleHAiOjE2NjY5Mjk1MTV9.N8MGU2g8tLyQS0KwEV6f0SLjT8OOpQiMZhHm-a4mtCE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5Mzc5LCJleHAiOjE2Njc3MTg1Nzl9.82_Jebm92jGdarEc5Pnyoa1kDmiK6IzUUEY1LgeoXpM
 Host: www.smody.co.kr</code></pre>
 </div>
 </div>
@@ -551,7 +551,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 320
+Content-Length: 334
 
 [ {
   "challengeId" : 1,
@@ -630,7 +630,7 @@ Content-Length: 320
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /challenges/me?size=10&amp;cursorId=7 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzE2LCJleHAiOjE2NjY5Mjk1MTZ9.bW8HOEhUj6PtvBG0S3bnEq0eIhxpYogRkohnWL5KOUw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5MzgwLCJleHAiOjE2Njc3MTg1ODB9.sdio6o2Pw8qmv6Y8x8CQQJ78K6bO8GO91kGgB53ZMzE
 Host: www.smody.co.kr</code></pre>
 </div>
 </div>
@@ -644,7 +644,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 389
+Content-Length: 407
 
 [ {
   "challengeId" : 1,
@@ -731,7 +731,7 @@ Host: www.smody.co.kr</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /challenges/1/auth HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzE2LCJleHAiOjE2NjY5Mjk1MTZ9.bW8HOEhUj6PtvBG0S3bnEq0eIhxpYogRkohnWL5KOUw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5MzgwLCJleHAiOjE2Njc3MTg1ODB9.sdio6o2Pw8qmv6Y8x8CQQJ78K6bO8GO91kGgB53ZMzE
 Host: www.smody.co.kr</code></pre>
 </div>
 </div>
@@ -745,7 +745,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 214
+Content-Length: 222
 
 {
   "challengeId" : 1,
@@ -836,7 +836,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 290
+Content-Length: 302
 
 [ {
   "memberId" : 1,
@@ -909,8 +909,8 @@ Content-Length: 290
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /challenges HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzE2LCJleHAiOjE2NjY5Mjk1MTZ9.bW8HOEhUj6PtvBG0S3bnEq0eIhxpYogRkohnWL5KOUw
-Content-Length: 160
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5MzgwLCJleHAiOjE2Njc3MTg1ODB9.sdio6o2Pw8qmv6Y8x8CQQJ78K6bO8GO91kGgB53ZMzE
+Content-Length: 165
 Host: www.smody.co.kr
 
 {
@@ -992,7 +992,7 @@ Host: www.smody.co.kr</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /challenges/auth?size=10&amp;cursorId=9&amp;filter=%EA%B3%B5%EB%B6%80 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzE1LCJleHAiOjE2NjY5Mjk1MTV9.N8MGU2g8tLyQS0KwEV6f0SLjT8OOpQiMZhHm-a4mtCE
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5MzgwLCJleHAiOjE2Njc3MTg1ODB9.sdio6o2Pw8qmv6Y8x8CQQJ78K6bO8GO91kGgB53ZMzE
 Host: www.smody.co.kr</code></pre>
 </div>
 </div>
@@ -1006,7 +1006,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 330
+Content-Length: 344
 
 [ {
   "challengeId" : 1,
@@ -1032,7 +1032,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 329
+Content-Length: 343
 
 [ {
   "challengeId" : 1,
@@ -1111,7 +1111,7 @@ Content-Length: 329
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /challenges/me/1 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzE2LCJleHAiOjE2NjY5Mjk1MTZ9.bW8HOEhUj6PtvBG0S3bnEq0eIhxpYogRkohnWL5KOUw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5MzgwLCJleHAiOjE2Njc3MTg1ODB9.sdio6o2Pw8qmv6Y8x8CQQJ78K6bO8GO91kGgB53ZMzE
 Host: www.smody.co.kr</code></pre>
 </div>
 </div>
@@ -1125,7 +1125,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 195
+Content-Length: 202
 
 {
   "challengeName" : "알고리즘 풀기",
@@ -1199,12 +1199,12 @@ Content-Length: 195
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /cycles HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzMwLCJleHAiOjE2NjY5Mjk1MzB9.Uv4IY6f03PrKl9IjaNN8kJuQoyvnwtUyfAVTsIjGWiQ
-Content-Length: 66
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5Mzg1LCJleHAiOjE2Njc3MTg1ODV9.FZpuuOUCBbqliJAcXWXix3pglU6D7q3RA7nWznwkh54
+Content-Length: 73
 Host: www.smody.co.kr
 
 {
-  "startTime" : "2022-10-25T12:58:50.347",
+  "startTime" : "2022-11-03T16:09:45.0758816",
   "challengeId" : 1
 }</code></pre>
 </div>
@@ -1262,7 +1262,7 @@ Location: /cycles/1</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /cycles/1/progress HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzI5LCJleHAiOjE2NjY5Mjk1Mjl9.UphwsCYEx5-fSrgT7F4Afh_plMCt8me2pjnMqsHaYGU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5Mzg0LCJleHAiOjE2Njc3MTg1ODR9.Ok2UBj5XddWUFq73KFyT3P4aPjvTl5gC2X2J8472sJ4
 Host: www.smody.co.kr
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -1326,10 +1326,11 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 25
+Content-Length: 51
 
 {
-  "progressCount" : 2
+  "progressCount" : 2,
+  "cycleDetailId" : 1
 }</code></pre>
 </div>
 </div>
@@ -1355,6 +1356,11 @@ Content-Length: 25
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사이클 진척도</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cycleDetailId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생성된 인증 ID</p></td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -1368,7 +1374,7 @@ Content-Length: 25
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /cycles/me?page=0&amp;size=5 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzI5LCJleHAiOjE2NjY5Mjk1Mjl9.UphwsCYEx5-fSrgT7F4Afh_plMCt8me2pjnMqsHaYGU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5Mzg0LCJleHAiOjE2Njc3MTg1ODR9.Ok2UBj5XddWUFq73KFyT3P4aPjvTl5gC2X2J8472sJ4
 Host: www.smody.co.kr</code></pre>
 </div>
 </div>
@@ -1382,14 +1388,14 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 424
+Content-Length: 448
 
 [ {
   "cycleId" : 1,
   "challengeId" : 1,
   "challengeName" : "미라클 모닝",
   "progressCount" : 2,
-  "startTime" : "2022-10-25T12:58:49.7129",
+  "startTime" : "2022-11-03T16:09:44.7098809",
   "successCount" : 3,
   "emojiIndex" : 0,
   "colorIndex" : 1
@@ -1398,7 +1404,7 @@ Content-Length: 424
   "challengeId" : 2,
   "challengeName" : "오늘의 운동",
   "progressCount" : 1,
-  "startTime" : "2022-10-25T12:58:49.7129",
+  "startTime" : "2022-11-03T16:09:44.7098809",
   "successCount" : 3,
   "emojiIndex" : 0,
   "colorIndex" : 1
@@ -1488,24 +1494,24 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 535
+Content-Length: 554
 
 {
   "cycleId" : 1,
   "challengeId" : 1,
   "challengeName" : "미라클 모닝",
   "progressCount" : 2,
-  "startTime" : "2022-10-25T12:58:50.175637",
+  "startTime" : "2022-11-03T16:09:45.009879",
   "successCount" : 3,
   "description" : "미라클 모닝입니다",
   "emojiIndex" : 0,
   "colorIndex" : 1,
   "cycleDetails" : [ {
-    "progressTime" : "2022-10-25T12:58:50.177631",
+    "progressTime" : "2022-11-03T16:09:45.009879",
     "progressImage" : "image1",
     "description" : "인증 내용1"
   }, {
-    "progressTime" : "2022-10-25T12:58:50.178083",
+    "progressTime" : "2022-11-03T16:09:45.009879",
     "progressImage" : "image2",
     "description" : "인증 내용2"
   } ]
@@ -1602,7 +1608,7 @@ Content-Length: 535
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /cycles/me/stat HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzI5LCJleHAiOjE2NjY5Mjk1Mjl9.UphwsCYEx5-fSrgT7F4Afh_plMCt8me2pjnMqsHaYGU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5Mzg0LCJleHAiOjE2Njc3MTg1ODR9.Ok2UBj5XddWUFq73KFyT3P4aPjvTl5gC2X2J8472sJ4
 Host: www.smody.co.kr</code></pre>
 </div>
 </div>
@@ -1616,7 +1622,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 45
+Content-Length: 48
 
 {
   "totalCount" : 35,
@@ -1664,7 +1670,7 @@ Content-Length: 45
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /cycles/me/1/?size=10&amp;lastCycleId=3 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzI5LCJleHAiOjE2NjY5Mjk1Mjl9.UphwsCYEx5-fSrgT7F4Afh_plMCt8me2pjnMqsHaYGU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5Mzg0LCJleHAiOjE2Njc3MTg1ODR9.Ok2UBj5XddWUFq73KFyT3P4aPjvTl5gC2X2J8472sJ4
 Host: www.smody.co.kr</code></pre>
 </div>
 </div>
@@ -1678,7 +1684,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 618
+Content-Length: 645
 
 [ {
   "cycleId" : 3,
@@ -1770,7 +1776,7 @@ Content-Length: 618
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /cycles/me/1/?size=10&amp;lastCycleId=3&amp;filter=success HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzI5LCJleHAiOjE2NjY5Mjk1Mjl9.UphwsCYEx5-fSrgT7F4Afh_plMCt8me2pjnMqsHaYGU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5Mzg0LCJleHAiOjE2Njc3MTg1ODR9.Ok2UBj5XddWUFq73KFyT3P4aPjvTl5gC2X2J8472sJ4
 Host: www.smody.co.kr</code></pre>
 </div>
 </div>
@@ -1784,7 +1790,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 692
+Content-Length: 722
 
 [ {
   "cycleId" : 3,
@@ -1893,7 +1899,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 630
+Content-Length: 654
 
 [ {
   "cycleDetailId" : 2,
@@ -2020,7 +2026,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 312
+Content-Length: 324
 
 {
   "cycleDetailId" : 2,
@@ -2129,7 +2135,7 @@ Host: www.smody.co.kr</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /feeds/1/comments/auth HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzI4LCJleHAiOjE2NjY5Mjk1Mjh9.n2EWpDPHoCZLTK-YXlWhx_HwXtItl19HDzfkCrmRizA
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5Mzg0LCJleHAiOjE2Njc3MTg1ODR9.Ok2UBj5XddWUFq73KFyT3P4aPjvTl5gC2X2J8472sJ4
 Host: www.smody.co.kr</code></pre>
 </div>
 </div>
@@ -2143,7 +2149,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 374
+Content-Length: 390
 
 [ {
   "memberId" : 1,
@@ -2171,7 +2177,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 373
+Content-Length: 389
 
 [ {
   "memberId" : 1,
@@ -2258,8 +2264,8 @@ Content-Length: 373
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /feeds/1/comments HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzI4LCJleHAiOjE2NjY5Mjk1Mjh9.n2EWpDPHoCZLTK-YXlWhx_HwXtItl19HDzfkCrmRizA
-Content-Length: 30
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5Mzg0LCJleHAiOjE2Njc3MTg1ODR9.Ok2UBj5XddWUFq73KFyT3P4aPjvTl5gC2X2J8472sJ4
+Content-Length: 32
 Host: www.smody.co.kr
 
 {
@@ -2315,8 +2321,8 @@ Location: /comments/1</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /comments/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzI4LCJleHAiOjE2NjY5Mjk1Mjh9.n2EWpDPHoCZLTK-YXlWhx_HwXtItl19HDzfkCrmRizA
-Content-Length: 33
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5Mzg0LCJleHAiOjE2Njc3MTg1ODR9.Ok2UBj5XddWUFq73KFyT3P4aPjvTl5gC2X2J8472sJ4
+Content-Length: 35
 Host: www.smody.co.kr
 
 {
@@ -2370,7 +2376,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /comments/1 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzI4LCJleHAiOjE2NjY5Mjk1Mjh9.n2EWpDPHoCZLTK-YXlWhx_HwXtItl19HDzfkCrmRizA
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5Mzg0LCJleHAiOjE2Njc3MTg1ODR9.Ok2UBj5XddWUFq73KFyT3P4aPjvTl5gC2X2J8472sJ4
 Host: www.smody.co.kr</code></pre>
 </div>
 </div>
@@ -2397,7 +2403,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members/me HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzM4LCJleHAiOjE2NjY5Mjk1Mzh9.z6ximtMeEMjxI5Hyx1RVujLHQA0bKGZ2DyH4H8GLBXs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5MzY2LCJleHAiOjE2Njc3MTg1NjZ9.Q2aKcT9pYdK_0n15R7Nmh1EdEM-v6xvwlyH1FDexpFQ
 Host: www.smody.co.kr</code></pre>
 </div>
 </div>
@@ -2411,7 +2417,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 123
+Content-Length: 128
 
 {
   "email" : "alpha@naver.com",
@@ -2472,8 +2478,8 @@ Content-Length: 123
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /members/me HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzM3LCJleHAiOjE2NjY5Mjk1Mzd9.YdSIzrklyEmj9LvAF8M9souzhX4iMZLdrkkJi_iZ6zU
-Content-Length: 54
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5MzY2LCJleHAiOjE2Njc3MTg1NjZ9.Q2aKcT9pYdK_0n15R7Nmh1EdEM-v6xvwlyH1FDexpFQ
+Content-Length: 57
 Host: www.smody.co.kr
 
 {
@@ -2534,7 +2540,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /members/me/profile-image HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzM4LCJleHAiOjE2NjY5Mjk1Mzh9.z6ximtMeEMjxI5Hyx1RVujLHQA0bKGZ2DyH4H8GLBXs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5MzY2LCJleHAiOjE2Njc3MTg1NjZ9.Q2aKcT9pYdK_0n15R7Nmh1EdEM-v6xvwlyH1FDexpFQ
 Host: www.smody.co.kr
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -2601,7 +2607,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 64
+Content-Length: 67
 
 {
   "accessToken" : "smodyAccessToken",
@@ -2649,7 +2655,7 @@ Content-Length: 64
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /members/me HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzM4LCJleHAiOjE2NjY5Mjk1Mzh9.z6ximtMeEMjxI5Hyx1RVujLHQA0bKGZ2DyH4H8GLBXs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5MzY2LCJleHAiOjE2Njc3MTg1NjZ9.Q2aKcT9pYdK_0n15R7Nmh1EdEM-v6xvwlyH1FDexpFQ
 Host: www.smody.co.kr</code></pre>
 </div>
 </div>
@@ -2675,7 +2681,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /oauth/check HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzE0LCJleHAiOjE2NjY5Mjk1MTR9._-RtsA_KQboq2Lf2F4tEVyd97etRDXtrNVQUrhvqHl0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5MzY3LCJleHAiOjE2Njc3MTg1Njd9.juWgU_dm2lBObjubS4Q8mSH8iY7bdLscjIeOUBoxIIk
 Host: www.smody.co.kr</code></pre>
 </div>
 </div>
@@ -2689,7 +2695,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 22
+Content-Length: 24
 
 {
   "isValid" : true
@@ -2728,13 +2734,70 @@ Content-Length: 22
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_request_27"><a class="link" href="#_request_27">Request</a></h3>
-<div class="paragraph">
-<p>Unresolved directive in api.adoc - include::/Users/jojogreen/Desktop/2022-smody/backend/smody/build/generated-snippets/mention-to/http-request.adoc[]
-=== Response
-Unresolved directive in api.adoc - include::/Users/jojogreen/Desktop/2022-smody/backend/smody/build/generated-snippets/mention-to/http-response.adoc[]
-=== Response 필드
-Unresolved directive in api.adoc - include::/Users/jojogreen/Desktop/2022-smody/backend/smody/build/generated-snippets/mention-to/response-fields.adoc[]</p>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY0NTAwODAxLCJleHAiOjE2NjQ3NjAwMDF9.q3EN-y60OLaTxGUvSyqy1fr0uN4FQL9nV3f--1Aojt0
+Host: www.smody.co.kr</code></pre>
 </div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_response_27"><a class="link" href="#_response_27">Response</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 155
+
+[ {
+  "memberId" : 3,
+  "nickname" : "알파",
+  "picture" : "사진"
+}, {
+  "memberId" : 5,
+  "nickname" : "알파쿤",
+  "picture" : "사진"
+} ]</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_response_필드_19"><a class="link" href="#_response_필드_19">Response 필드</a></h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[]memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[]nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[]picture</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사진</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 </div>
 </div>
@@ -2752,7 +2815,7 @@ Host: www.smody.co.kr</code></pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_27"><a class="link" href="#_response_27">Response</a></h3>
+<h3 id="_response_28"><a class="link" href="#_response_28">Response</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -2760,7 +2823,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 109
+Content-Length: 111
 
 {
   "publicKey" : "BNzzfdcBcThU27FcGve6F3GF6He2Fro82ZMuOLga9fukatLMlaKB6GdO-82loi6W4iGdPQZAp_4HLgST8z5of_E"
@@ -2779,8 +2842,8 @@ Content-Length: 109
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /web-push/subscribe HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzQwLCJleHAiOjE2NjY5Mjk1NDB9.iQuEB4I7Oev12ai6OCh866uNmsl9K4jhXEAKTZZTBxw
-Content-Length: 97
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5MzUxLCJleHAiOjE2Njc3MTg1NTF9.mrIUzIQ5i3YRhok1eGwPSZL0WRblVx7jcBgDyXFWPV4
+Content-Length: 103
 Host: www.smody.co.kr
 
 {
@@ -2828,7 +2891,7 @@ Host: www.smody.co.kr
 </table>
 </div>
 <div class="sect2">
-<h3 id="_response_28"><a class="link" href="#_response_28">Response</a></h3>
+<h3 id="_response_29"><a class="link" href="#_response_29">Response</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -2849,8 +2912,8 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /web-push/unsubscribe HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzM5LCJleHAiOjE2NjY5Mjk1Mzl9.L8KHU0R6Dg9CRZ6JsRMEYZvlvrhQaZ4uFnU-3VY4fFA
-Content-Length: 34
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5MzUwLCJleHAiOjE2Njc3MTg1NTB9.4a2r0FcbSVOBOwsJXEdBsz0pJCQpmHzvsKwjONaFXaY
+Content-Length: 36
 Host: www.smody.co.kr
 
 {
@@ -2884,7 +2947,7 @@ Host: www.smody.co.kr
 </table>
 </div>
 <div class="sect2">
-<h3 id="_response_29"><a class="link" href="#_response_29">Response</a></h3>
+<h3 id="_response_30"><a class="link" href="#_response_30">Response</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 204 No Content
@@ -2904,13 +2967,13 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /push-notifications HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzM5LCJleHAiOjE2NjY5Mjk1Mzl9.L8KHU0R6Dg9CRZ6JsRMEYZvlvrhQaZ4uFnU-3VY4fFA
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5MzUzLCJleHAiOjE2Njc3MTg1NTN9.6F1ACy5G787s4yNoQC1OToM7c1BeRwg5g8i1UmIno4g
 Host: www.smody.co.kr</code></pre>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_30"><a class="link" href="#_response_30">Response</a></h3>
+<h3 id="_response_31"><a class="link" href="#_response_31">Response</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -2918,18 +2981,18 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 405
+Content-Length: 419
 
 [ {
   "pushNotificationId" : 1,
   "message" : "조조그린님 스모디 알림이 구독되었습니다..",
-  "pushTime" : "2022-10-25T12:58:59.846235",
+  "pushTime" : "2022-11-03T16:09:13.4089906",
   "pathId" : 1,
   "pushCase" : "subscription"
 }, {
   "pushNotificationId" : 2,
   "message" : "미라클 모닝 챌린지 인증까지 얼마 안남았어요~",
-  "pushTime" : "2022-10-25T12:58:59.846318",
+  "pushTime" : "2022-11-03T16:09:13.4089906",
   "pathId" : 2,
   "pushCase" : "challenge"
 } ]</code></pre>
@@ -2937,7 +3000,7 @@ Content-Length: 405
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_필드_19"><a class="link" href="#_response_필드_19">Response 필드</a></h3>
+<h3 id="_response_필드_20"><a class="link" href="#_response_필드_20">Response 필드</a></h3>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -2990,13 +3053,13 @@ Content-Length: 405
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /push-notifications/1 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzM5LCJleHAiOjE2NjY5Mjk1Mzl9.L8KHU0R6Dg9CRZ6JsRMEYZvlvrhQaZ4uFnU-3VY4fFA
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5MzUzLCJleHAiOjE2Njc3MTg1NTN9.6F1ACy5G787s4yNoQC1OToM7c1BeRwg5g8i1UmIno4g
 Host: www.smody.co.kr</code></pre>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_31"><a class="link" href="#_response_31">Response</a></h3>
+<h3 id="_response_32"><a class="link" href="#_response_32">Response</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 204 No Content
@@ -3017,13 +3080,13 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /push-notifications/me HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzM5LCJleHAiOjE2NjY5Mjk1Mzl9.L8KHU0R6Dg9CRZ6JsRMEYZvlvrhQaZ4uFnU-3VY4fFA
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5MzUzLCJleHAiOjE2Njc3MTg1NTN9.6F1ACy5G787s4yNoQC1OToM7c1BeRwg5g8i1UmIno4g
 Host: www.smody.co.kr</code></pre>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_32"><a class="link" href="#_response_32">Response</a></h3>
+<h3 id="_response_33"><a class="link" href="#_response_33">Response</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 204 No Content
@@ -3049,7 +3112,7 @@ Host: www.smody.co.kr</code></pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_33"><a class="link" href="#_response_33">Response</a></h3>
+<h3 id="_response_34"><a class="link" href="#_response_34">Response</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -3057,7 +3120,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 184
+Content-Length: 192
 
 [ {
   "rankingPeriodId" : 1,
@@ -3072,7 +3135,7 @@ Content-Length: 184
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_필드_20"><a class="link" href="#_response_필드_20">Response 필드</a></h3>
+<h3 id="_response_필드_21"><a class="link" href="#_response_필드_21">Response 필드</a></h3>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -3120,7 +3183,7 @@ Host: www.smody.co.kr</code></pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_34"><a class="link" href="#_response_34">Response</a></h3>
+<h3 id="_response_35"><a class="link" href="#_response_35">Response</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -3128,7 +3191,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 303
+Content-Length: 317
 
 [ {
   "ranking" : 1,
@@ -3149,7 +3212,7 @@ Content-Length: 303
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_필드_21"><a class="link" href="#_response_필드_21">Response 필드</a></h3>
+<h3 id="_response_필드_22"><a class="link" href="#_response_필드_22">Response 필드</a></h3>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -3207,13 +3270,13 @@ Content-Length: 303
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /ranking-periods/1/ranking-activities/me HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzU0LCJleHAiOjE2NjY5Mjk1NTR9.hHIWMEECWHHfCQrPbmymhuJ5zDlkthvszBLLpXbMm_8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5MzYyLCJleHAiOjE2Njc3MTg1NjJ9.qN9sfYhZEa8exG5fcgIgXaAu-M6Fnx7pvqzRI1tjIn4
 Host: www.smody.co.kr</code></pre>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_35"><a class="link" href="#_response_35">Response</a></h3>
+<h3 id="_response_36"><a class="link" href="#_response_36">Response</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -3221,7 +3284,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 152
+Content-Length: 159
 
 {
   "ranking" : 1,
@@ -3235,7 +3298,7 @@ Content-Length: 152
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_필드_22"><a class="link" href="#_response_필드_22">Response 필드</a></h3>
+<h3 id="_response_필드_23"><a class="link" href="#_response_필드_23">Response 필드</a></h3>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -3294,8 +3357,8 @@ Content-Length: 152
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /push-notifications HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzM5LCJleHAiOjE2NjY5Mjk1Mzl9.L8KHU0R6Dg9CRZ6JsRMEYZvlvrhQaZ4uFnU-3VY4fFA
-Content-Length: 44
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5MzUzLCJleHAiOjE2Njc3MTg1NTN9.6F1ACy5G787s4yNoQC1OToM7c1BeRwg5g8i1UmIno4g
+Content-Length: 47
 Host: www.smody.co.kr
 
 {
@@ -3335,7 +3398,7 @@ Host: www.smody.co.kr
 </table>
 </div>
 <div class="sect2">
-<h3 id="_response_36"><a class="link" href="#_response_36">Response</a></h3>
+<h3 id="_response_37"><a class="link" href="#_response_37">Response</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -3361,7 +3424,7 @@ Host: www.smody.co.kr</code></pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_37"><a class="link" href="#_response_37">Response</a></h3>
+<h3 id="_response_38"><a class="link" href="#_response_38">Response</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -3369,7 +3432,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 184
+Content-Length: 192
 
 [ {
   "rankingPeriodId" : 1,
@@ -3384,7 +3447,7 @@ Content-Length: 184
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_필드_23"><a class="link" href="#_response_필드_23">Response 필드</a></h3>
+<h3 id="_response_필드_24"><a class="link" href="#_response_필드_24">Response 필드</a></h3>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -3432,7 +3495,7 @@ Host: www.smody.co.kr</code></pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_38"><a class="link" href="#_response_38">Response</a></h3>
+<h3 id="_response_39"><a class="link" href="#_response_39">Response</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -3440,7 +3503,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 303
+Content-Length: 317
 
 [ {
   "ranking" : 1,
@@ -3461,7 +3524,7 @@ Content-Length: 303
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_필드_24"><a class="link" href="#_response_필드_24">Response 필드</a></h3>
+<h3 id="_response_필드_25"><a class="link" href="#_response_필드_25">Response 필드</a></h3>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -3519,13 +3582,13 @@ Content-Length: 303
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /ranking-periods/1/ranking-activities/me HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY2NjcwMzU0LCJleHAiOjE2NjY5Mjk1NTR9.hHIWMEECWHHfCQrPbmymhuJ5zDlkthvszBLLpXbMm_8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjY3NDU5MzYyLCJleHAiOjE2Njc3MTg1NjJ9.qN9sfYhZEa8exG5fcgIgXaAu-M6Fnx7pvqzRI1tjIn4
 Host: www.smody.co.kr</code></pre>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_39"><a class="link" href="#_response_39">Response</a></h3>
+<h3 id="_response_40"><a class="link" href="#_response_40">Response</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -3533,7 +3596,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 152
+Content-Length: 159
 
 {
   "ranking" : 1,
@@ -3547,7 +3610,7 @@ Content-Length: 152
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_필드_25"><a class="link" href="#_response_필드_25">Response 필드</a></h3>
+<h3 id="_response_필드_26"><a class="link" href="#_response_필드_26">Response 필드</a></h3>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -3601,7 +3664,7 @@ Content-Length: 152
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2022-10-17 14:48:00 +0900
+Last updated 2022-10-17 17:17:10 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/backend/smody/src/test/java/com/woowacourse/smody/acceptance/CycleAcceptanceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/acceptance/CycleAcceptanceTest.java
@@ -56,7 +56,8 @@ class CycleAcceptanceTest extends AcceptanceTest {
         ProgressResponse actual = toResponseDto(response, ProgressResponse.class);
         assertAll(
             OK_응답(response),
-            () -> assertThat(actual.getProgressCount()).isEqualTo(1)
+            () -> assertThat(actual.getProgressCount()).isEqualTo(1),
+            () -> assertThat(actual.getCycleDetailId()).isNotNull()
         );
     }
 

--- a/backend/smody/src/test/java/com/woowacourse/smody/cycle/controller/CycleControllerTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/cycle/controller/CycleControllerTest.java
@@ -94,7 +94,7 @@ class CycleControllerTest extends ControllerTest {
     void increaseProgress_200() throws Exception {
         // given
         String token = jwtTokenProvider.createToken(new TokenPayload(1L));
-        ProgressResponse response = new ProgressResponse(2);
+        ProgressResponse response = new ProgressResponse(2, 1L);
         given(cycleApiService.increaseProgress(any(TokenPayload.class), any(ProgressRequest.class)))
                 .willReturn(response);
 
@@ -116,7 +116,8 @@ class CycleControllerTest extends ControllerTest {
                                 parameterWithName("description").description("인증 설명")
                         ),
                         responseFields(
-                                fieldWithPath("progressCount").type(JsonFieldType.NUMBER).description("사이클 진척도")
+                                fieldWithPath("progressCount").type(JsonFieldType.NUMBER).description("사이클 진척도"),
+                                fieldWithPath("cycleDetailId").type(JsonFieldType.NUMBER).description("생성된 인증 ID")
                         )));
     }
 

--- a/backend/smody/src/test/java/com/woowacourse/smody/cycle/service/CycleApiServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/cycle/service/CycleApiServiceTest.java
@@ -95,7 +95,10 @@ public class CycleApiServiceTest extends IntegrationTest {
         ProgressResponse progressResponse = cycleApiService.increaseProgress(tokenPayload, request);
 
         // then
-        assertThat(progressResponse.getProgressCount()).isEqualTo(expected);
+        assertAll(
+            () -> assertThat(progressResponse.getProgressCount()).isEqualTo(expected),
+            () -> assertThat(progressResponse.getCycleDetailId()).isNotNull()
+        );
     }
 
     @DisplayName("진행도를 증가 시킬 때 유효하지 않은 시간인 경우 예외 발생")


### PR DESCRIPTION
챌린지 인증 시 (피드 작성 시)에도 맨션을 하고 싶다는 요구가 들어왔어요. 기존에 있던 맨션 api를 사용하면 되는 문제지만 그러려면 pathId로 cycleDetailId가 필요합니다.

기존의 사이클 진척도 증가 api의 응답으로는 주고 있지 않던 정보라서 추가하기로 했습니다.
![image](https://user-images.githubusercontent.com/78652144/199666311-a54b4389-e585-4dc3-a796-52ef7c45ed20.png)
 
그래서 다음과 같이 반영했습니다.
![image](https://user-images.githubusercontent.com/78652144/199666756-04618038-1954-4180-a338-5db36851f29e.png)

### 문제 상황
그런데 이렇게 하니 cycleDetailId가 null인 현상이 발생했습니다. 일반적인 insert 문이라면 바로 SQL을 날려 id를 받아왔을 것입니다. 하지만 우리는 `CycleDetail`을 영속성 전이로 저장하고 있습니다. (`Cascade.PERSIST`) 영속성 전이로 발생한 저장은 `flush()` 시점에 쿼리가 날아가기 때문에 DTO를 세팅하는 저 시점은 `flush()` 전이라 id가 null인 것입니다.

### 해결 방법
강제적인 `flush()` 호출이 필요했습니다. 그런데 기존의 `CycleApiService`에서는 `EntityManager`나 `CycleRepository`가 없어 추가적인 의존이 필요한 상황입니다. 그래서 원래 `CycleRepository`를 가지고 있는 `CycleService`가 `flush()`를 해주도록 `increaseProgress()` 메서드를 `CycleService`가 하도록 변경했습니다.

![image](https://user-images.githubusercontent.com/78652144/199667570-3269585d-3d04-4ecc-9548-cbb28ab344ca.png)


![image](https://user-images.githubusercontent.com/78652144/199667545-97e5fd29-a393-42b1-b364-ecd4a05e10ae.png)


리뷰 잘 부탁드립니다!
