### PR TITLE
feat: (fe) 챌린지 페이지 탭 순서 변경

### DIFF
--- a/frontend/src/components/Navbar/index.tsx
+++ b/frontend/src/components/Navbar/index.tsx
@@ -26,7 +26,7 @@ export const Navbar = () => {
               alignItems="center"
               gap="6px"
               as={Link}
-              to={CLIENT_PATH.CHALLENGE_EVENT}
+              to={CLIENT_PATH.CHALLENGE_RANDOM}
             >
               <ImFire size={23} color={challengeColor} />
               <Text size={11} color={challengeColor} aria-label="챌린지 탭">

--- a/frontend/src/pages/ChallengePage/index.tsx
+++ b/frontend/src/pages/ChallengePage/index.tsx
@@ -11,20 +11,20 @@ import { CLIENT_PATH } from 'constants/path';
 
 const tabList = [
   {
-    path: CLIENT_PATH.CHALLENGE_EVENT,
-    tabName: '⭐ 이벤트',
+    path: CLIENT_PATH.CHALLENGE_RANDOM,
+    tabName: '🎲 추천',
   },
   {
     path: CLIENT_PATH.CHALLENGE_POPULAR,
     tabName: '🔥 인기',
   },
   {
-    path: CLIENT_PATH.CHALLENGE_RANDOM,
-    tabName: '🎲 추천',
-  },
-  {
     path: CLIENT_PATH.CHALLENGE_SEARCH,
     tabName: '🔎 검색',
+  },
+  {
+    path: CLIENT_PATH.CHALLENGE_EVENT,
+    tabName: '⭐ 이벤트',
   },
 ];
 

--- a/frontend/src/pages/EventPage/index.tsx
+++ b/frontend/src/pages/EventPage/index.tsx
@@ -18,10 +18,10 @@ const EventPage = () => {
       as="section"
     >
       <TitleText color={themeContext.onBackground} size={20} fontWeight="bold" as="h1">
-        ⭐ 우테코 팀프로젝트 사용 챌린지 이벤트 ⭐
+        ⭐ 우테코 팀프로젝트 사용 챌린지 ⭐
       </TitleText>
       <DescriptionText color={themeContext.onBackground} size={16}>
-        챌린지를 1회라도 인증한다면 추첨을 통해 스모디 컵을 드립니다!
+        우테코 4기의 다른 프로젝트를 이용해 보세요!
       </DescriptionText>
       <FlexBox as="ul" flexDirection="column" gap="27px">
         {EVENT_CHALLENGE_ID_LIST.map((challengeId: number) => (


### PR DESCRIPTION
close #648

- [x] 챌린지 페이지 하위 탭 순서 변경
  - 추천 -> 인기 -> 검색 -> 우테코 챌린지
- [x]  내브바의 챌린지 탭 클릭 시 추천 챌린지 페이지로 이동하도록 수정
- [x]  우테코 이벤트 챌린지 페이지 상세 설명 수정
