### PR TITLE
feat: (fe) 스크린리더의 모달 사용성 개선

### DIFF
--- a/frontend/src/components/@shared/ModalOverlay/index.tsx
+++ b/frontend/src/components/@shared/ModalOverlay/index.tsx
@@ -1,5 +1,5 @@
 import { ModalOverlayProps, ModalProps } from './type';
-import { PropsWithChildren } from 'react';
+import { useRef, useEffect, PropsWithChildren } from 'react';
 import ReactDOM from 'react-dom';
 import styled, { css } from 'styled-components';
 
@@ -10,6 +10,18 @@ export const ModalOverlay = ({
   handleCloseModal,
   isFullSize = false,
 }: PropsWithChildren<ModalOverlayProps>) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const rootElement = document.getElementById('root') as HTMLElement;
+    modalRef.current?.focus();
+    rootElement.setAttribute('aria-hidden', 'true');
+
+    return () => {
+      rootElement.removeAttribute('aria-hidden');
+    };
+  }, []);
+
   return (
     <>
       {ReactDOM.createPortal(
@@ -17,7 +29,7 @@ export const ModalOverlay = ({
         document.getElementById('backdrop-root') as HTMLElement,
       )}
       {ReactDOM.createPortal(
-        <Modal isFullSize={isFullSize} role="dialog" aria-modal="true">
+        <Modal ref={modalRef} isFullSize={isFullSize} role="dialog" tabIndex={0}>
           {children}
         </Modal>,
         document.getElementById('overlay-root') as HTMLElement,

--- a/frontend/src/components/SuccessModal/index.tsx
+++ b/frontend/src/components/SuccessModal/index.tsx
@@ -25,7 +25,6 @@ export const SuccessModal = ({
 }: SuccessModalProps) => {
   const themeContext = useThemeContext();
   const {
-    wrapperRef,
     successMessage,
     isChallengeComplete,
     handleClickClose,
@@ -44,14 +43,11 @@ export const SuccessModal = ({
   return (
     <ModalOverlay handleCloseModal={handleClickClose}>
       <Wrapper
-        ref={wrapperRef}
         flexDirection="column"
         alignItems="center"
         justifyContent="center"
         gap="1rem"
-        role="dialog"
         aria-label="인증 성공 모달"
-        tabIndex={0}
       >
         <CloseButton onClick={handleClickClose} aria-label="닫기">
           <Close />

--- a/frontend/src/components/SuccessModal/useSuccessModal.ts
+++ b/frontend/src/components/SuccessModal/useSuccessModal.ts
@@ -39,8 +39,6 @@ const useSuccessModal = ({
     elementSize: 17,
   });
 
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
   const isEvent = EVENT_CHALLENGE_ID_LIST.includes(challengeId);
   const { reward: emojiReward } = useReward('emojiRewardId', 'emoji', {
     emoji: isEvent ? ['❤️', '🧡', '💛', '💚', '💙', '💜'] : [emojiList[emojiIndex]],
@@ -82,12 +80,9 @@ const useSuccessModal = ({
   useEffect(() => {
     confettiReward();
     emojiReward();
-
-    wrapperRef.current!.focus();
   }, []);
 
   return {
-    wrapperRef,
     successMessage,
     isChallengeComplete,
     handleClickClose,

--- a/frontend/src/pages/ProfileEditPage/components/UserWithdrawalModal/index.tsx
+++ b/frontend/src/pages/ProfileEditPage/components/UserWithdrawalModal/index.tsx
@@ -1,4 +1,5 @@
 import useUserWithdrawalModal from './useUserWithdrawalModal';
+import Close from 'assets/close.svg';
 import styled, { css } from 'styled-components';
 
 import useThemeContext from 'hooks/useThemeContext';
@@ -19,6 +20,9 @@ export const UserWithdrawalModal = ({
   return (
     <ModalOverlay handleCloseModal={handleCloseModal}>
       <Wrapper flexDirection="column" alignItems="center" gap="1.5rem">
+        <CloseButton onClick={handleCloseModal} aria-label="닫기">
+          <Close />
+        </CloseButton>
         <Text color={themeContext.primary} size={20} fontWeight="bold">
           정말로 떠나시겠습니까?
         </Text>
@@ -56,6 +60,11 @@ export const UserWithdrawalModal = ({
 const Wrapper = styled(FlexBox)`
   width: 100%;
   padding: 2rem 1rem;
+  padding: 1rem 1rem 2rem;
+`;
+
+const CloseButton = styled.button`
+  align-self: flex-end;
 `;
 
 const WithdrawalButton = styled(Button)`


### PR DESCRIPTION
cloes #661 

# 작업 현황
## 모달이 렌더링 됐을 때 다른 요소에 포커스가 이동하지 않도록 수정
회원 탈퇴 모달이 렌더링 됐을 때도 스크린리더의 포커스가 이동하도록 구현했습니다. 그 과정에서 기존에 SuccessModal 컴포넌트에 있던 포커스 관련 로직을 ModalOverlay 컴포넌트로 이동시켰습니다.

그에 따라 스크린리더의 포커스가 모달 영역 밖으로 이동할 수 있는 문제가 발생했습니다.
따라서 이를 해결하기 위해 모달이 렌더링 됐을 때 `id=root` 인 태그에 aria-hidden 속성을 추가하도록 구현했습니다.

[관련 작업 커밋 - 7570b7f](https://github.com/woowacourse-teams/2022-smody/pull/662/commits/7570b7ff1542d2f3057aecbdf20b6e3dfe79c880)

## 회원 탈퇴 모달에 닫기 버튼 추가
기존에 닫기 버튼이 없었기 때문에 스크린 리더 사용자는 모달을 닫을 수 없었습니다.
이 문제를 해결하기 위해 닫기 버튼을 추가했습니다.

- 변경 전 회원 탈퇴 모달
<img width="472" alt="변경 전 회원탈퇴 모달" src="https://user-images.githubusercontent.com/52148907/200496058-f51bf65c-10d5-4350-a399-a40a525cf049.png">

- 변경 후 회원 탈퇴 모달
<img width="472" alt="변경 후 회원탈퇴 모달" src="https://user-images.githubusercontent.com/52148907/200496066-944e7588-fd71-40c8-b54b-a4a900793e1e.png">

[관련 작업 커밋 - 1ffe3db](https://github.com/woowacourse-teams/2022-smody/pull/662/commits/1ffe3db054ca716cf96819df848c92729795b788)
