### PR TITLE
feat: (fe) 피드 상세 페이지 useGetFeedById 테스트 추가

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import Router from 'Router';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
+import { BrowserRouter } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { isDarkState } from 'recoil/darkMode/atoms';
 import { ThemeProvider } from 'styled-components';
@@ -29,7 +30,9 @@ const App = () => {
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={isDark ? darkTheme : lightTheme}>
         <GlobalStyle />
-        <Router />
+        <BrowserRouter>
+          <Router />
+        </BrowserRouter>
         <ReactQueryDevtools initialIsOpen={true} />
       </ThemeProvider>
     </QueryClientProvider>

--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -37,52 +37,44 @@ const CertFlowPage = () => {
 
 const Router = () => {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route element={<Layout />}>
-          <Route index element={<LandingNavigation />} />
+    <Routes>
+      <Route element={<Layout />}>
+        <Route index element={<LandingNavigation />} />
 
-          <Route element={<PrivateOutlet />}>
-            <Route path={CLIENT_PATH.PROFILE} element={<ProfilePage />} />
-            <Route path={CLIENT_PATH.PROFILE_EDIT} element={<ProfileEditPage />} />
-            <Route path={CLIENT_PATH.CERT} element={<CertFlowPage />} />
-            <Route
-              path={CLIENT_PATH.CHALLENGE_CREATE}
-              element={<ChallengeCreatePage />}
-            />
-            <Route
-              path={CLIENT_PATH.PROFILE_CHALLENGE_DETAIL_ID}
-              element={<ChallengeRecordsPage />}
-            />
-            <Route
-              path={CLIENT_PATH.CYCLE_DETAIL_SHARE_ID}
-              element={<CycleDetailSharePage />}
-            />
-          </Route>
-
-          <Route path={CLIENT_PATH.HOME} element={<LandingPage />} />
-          <Route path={CLIENT_PATH.FEED} element={<FeedPage />} />
-          <Route path={CLIENT_PATH.FEED_DETAIL_ID} element={<FeedDetailPage />} />
-          <Route path={CLIENT_PATH.CYCLE_DETAIL_ID} element={<CycleDetailPage />} />
+        <Route element={<PrivateOutlet />}>
+          <Route path={CLIENT_PATH.PROFILE} element={<ProfilePage />} />
+          <Route path={CLIENT_PATH.PROFILE_EDIT} element={<ProfileEditPage />} />
+          <Route path={CLIENT_PATH.CERT} element={<CertFlowPage />} />
+          <Route path={CLIENT_PATH.CHALLENGE_CREATE} element={<ChallengeCreatePage />} />
           <Route
-            path={CLIENT_PATH.CHALLENGE_DETAIL_ID}
-            element={<ChallengeDetailPage />}
+            path={CLIENT_PATH.PROFILE_CHALLENGE_DETAIL_ID}
+            element={<ChallengeRecordsPage />}
           />
-
-          <Route path={CLIENT_PATH.RANK} element={<RankingPage />} />
-
-          <Route path={CLIENT_PATH.CHALLENGE_EVENT} element={<ChallengePage />} />
-          <Route path={CLIENT_PATH.CHALLENGE_SEARCH} element={<ChallengePage />} />
-          <Route path={CLIENT_PATH.CHALLENGE_RANDOM} element={<ChallengePage />} />
-          <Route path={CLIENT_PATH.CHALLENGE_POPULAR} element={<ChallengePage />} />
-
-          <Route path={CLIENT_PATH.VOC} element={<VocPage />} />
-
-          <Route path={CLIENT_PATH.NOT_FOUND} element={<NotFoundPage />} />
-          <Route path={CLIENT_PATH.WILD_CARD} element={<NotFoundPage />} />
+          <Route
+            path={CLIENT_PATH.CYCLE_DETAIL_SHARE_ID}
+            element={<CycleDetailSharePage />}
+          />
         </Route>
-      </Routes>
-    </BrowserRouter>
+
+        <Route path={CLIENT_PATH.HOME} element={<LandingPage />} />
+        <Route path={CLIENT_PATH.FEED} element={<FeedPage />} />
+        <Route path={CLIENT_PATH.FEED_DETAIL_ID} element={<FeedDetailPage />} />
+        <Route path={CLIENT_PATH.CYCLE_DETAIL_ID} element={<CycleDetailPage />} />
+        <Route path={CLIENT_PATH.CHALLENGE_DETAIL_ID} element={<ChallengeDetailPage />} />
+
+        <Route path={CLIENT_PATH.RANK} element={<RankingPage />} />
+
+        <Route path={CLIENT_PATH.CHALLENGE_EVENT} element={<ChallengePage />} />
+        <Route path={CLIENT_PATH.CHALLENGE_SEARCH} element={<ChallengePage />} />
+        <Route path={CLIENT_PATH.CHALLENGE_RANDOM} element={<ChallengePage />} />
+        <Route path={CLIENT_PATH.CHALLENGE_POPULAR} element={<ChallengePage />} />
+
+        <Route path={CLIENT_PATH.VOC} element={<VocPage />} />
+
+        <Route path={CLIENT_PATH.NOT_FOUND} element={<NotFoundPage />} />
+        <Route path={CLIENT_PATH.WILD_CARD} element={<NotFoundPage />} />
+      </Route>
+    </Routes>
   );
 };
 

--- a/frontend/src/__test__/certPage.test.tsx
+++ b/frontend/src/__test__/certPage.test.tsx
@@ -1,15 +1,15 @@
+import { renderWithProviders } from '__test__/utils/renderWithProviders';
 import { authApiClient } from 'apis/apiClient';
 import { accessTokenData } from 'mocks/data';
-import { renderWithProviders } from 'utils/testUtils';
 
 import { screen, waitFor } from '@testing-library/react';
 
-import { CertPage } from 'pages';
+import { CLIENT_PATH } from 'constants/path';
 
 describe('인증 페이지 테스트', () => {
   beforeEach(() => {
     authApiClient.updateAuth(accessTokenData);
-    renderWithProviders(<CertPage />);
+    renderWithProviders({ route: CLIENT_PATH.CERT });
   });
 
   test('[useGetMyCyclesInProgress] query 응답에 따라 내가 진행중인 챌린지가 렌더링되는지 확인한다.', async () => {

--- a/frontend/src/__test__/feedDetailPage.test.tsx
+++ b/frontend/src/__test__/feedDetailPage.test.tsx
@@ -1,0 +1,30 @@
+import { renderWithProviders } from '__test__/utils/renderWithProviders';
+import { authApiClient } from 'apis/apiClient';
+import { accessTokenData } from 'mocks/data';
+import { feedData } from 'mocks/data';
+
+import { screen, waitFor } from '@testing-library/react';
+
+describe('피드 상세 페이지 테스트', () => {
+  const mockedFeedData = feedData[0];
+
+  beforeEach(() => {
+    const route = `/feed/detail/${mockedFeedData.cycleDetailId}`;
+
+    authApiClient.updateAuth(accessTokenData);
+    renderWithProviders({ route });
+  });
+
+  test('[useGetFeedById] 조회한 피드의 description이 mocking된 피드 데이터의 description과 일치한다.', async () => {
+    const DESCRIPTION_LABEL = '피드 내용';
+    const EXPECTED_DESCRIPTION = mockedFeedData.description;
+
+    const descriptionElement = await waitFor(() =>
+      screen.getByLabelText(DESCRIPTION_LABEL),
+    );
+
+    await waitFor(() =>
+      expect(descriptionElement).toHaveTextContent(EXPECTED_DESCRIPTION),
+    );
+  });
+});

--- a/frontend/src/__test__/feedDetailPage.test.tsx
+++ b/frontend/src/__test__/feedDetailPage.test.tsx
@@ -2,29 +2,34 @@ import { renderWithProviders } from '__test__/utils/renderWithProviders';
 import { authApiClient } from 'apis/apiClient';
 import { accessTokenData } from 'mocks/data';
 import { feedData } from 'mocks/data';
+import { act } from 'react-dom/test-utils';
 
 import { screen, waitFor } from '@testing-library/react';
 
 describe('피드 상세 페이지 테스트', () => {
   const mockedFeedData = feedData[0];
-
-  beforeEach(() => {
+  beforeEach(async () => {
     const route = `/feed/detail/${mockedFeedData.cycleDetailId}`;
-
     authApiClient.updateAuth(accessTokenData);
-    renderWithProviders({ route });
+
+    await act(() => {
+      renderWithProviders({ route });
+    });
   });
 
   test('[useGetFeedById] 조회한 피드의 description이 mocking된 피드 데이터의 description과 일치한다.', async () => {
+    // given
     const DESCRIPTION_LABEL = '피드 내용';
-    const EXPECTED_DESCRIPTION = mockedFeedData.description;
+    const expectedDescription = mockedFeedData.description;
 
+    // when
     const descriptionElement = await waitFor(() =>
       screen.getByLabelText(DESCRIPTION_LABEL),
     );
 
+    // then
     await waitFor(() =>
-      expect(descriptionElement).toHaveTextContent(EXPECTED_DESCRIPTION),
+      expect(descriptionElement).toHaveTextContent(expectedDescription),
     );
   });
 });

--- a/frontend/src/__test__/profilePage.test.tsx
+++ b/frontend/src/__test__/profilePage.test.tsx
@@ -1,15 +1,15 @@
+import { renderWithProviders } from '__test__/utils/renderWithProviders';
 import { authApiClient } from 'apis/apiClient';
 import { accessTokenData } from 'mocks/data';
-import { renderWithProviders } from 'utils/testUtils';
 
 import { screen, waitFor } from '@testing-library/react';
 
-import { ProfilePage } from 'pages';
+import { CLIENT_PATH } from 'constants/path';
 
 describe('프로필 페이지 테스트', () => {
   beforeEach(() => {
     authApiClient.updateAuth(accessTokenData);
-    renderWithProviders(<ProfilePage />);
+    renderWithProviders({ route: CLIENT_PATH.PROFILE });
   });
 
   test('[useGetMyInfo] query 응답에 따라 나의 프로필 정보가 렌더링되는지 확인한다.', async () => {

--- a/frontend/src/__test__/searchPage.test.tsx
+++ b/frontend/src/__test__/searchPage.test.tsx
@@ -1,12 +1,12 @@
-import { renderWithProviders } from 'utils/testUtils';
+import { renderWithProviders } from '__test__/utils/renderWithProviders';
 
 import { screen, waitFor } from '@testing-library/react';
 
-import { SearchPage } from 'pages';
+import { CLIENT_PATH } from 'constants/path';
 
 describe('검색 페이지 테스트', () => {
   beforeEach(() => {
-    renderWithProviders(<SearchPage />);
+    renderWithProviders({ route: CLIENT_PATH.CHALLENGE_SEARCH });
   });
 
   test('[useGetAllChallenges] query 응답에 따라 모든 챌린지가 렌더링되는지 확인한다.', async () => {

--- a/frontend/src/__test__/utils/renderWithProviders.tsx
+++ b/frontend/src/__test__/utils/renderWithProviders.tsx
@@ -1,6 +1,7 @@
+import Router from 'Router';
+import { renderWithProvidersProps } from '__test__/utils/type';
 import { generateQueryClient } from 'queryClient';
-import { ReactElement } from 'react';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import { QueryClientProvider } from 'react-query';
 import { MemoryRouter } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
 import { ThemeProvider } from 'styled-components';
@@ -16,17 +17,15 @@ const generateTestQueryClient = () => {
   return client;
 };
 
-export function renderWithProviders(
-  ui: ReactElement,
-  client?: QueryClient,
-): RenderResult {
-  const queryClient = client ?? generateTestQueryClient();
+export function renderWithProviders({ route }: renderWithProvidersProps): RenderResult {
   return render(
     <RecoilRoot>
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <ThemeProvider theme={darkTheme}>{ui}</ThemeProvider>
-        </MemoryRouter>
+      <QueryClientProvider client={generateTestQueryClient()}>
+        <ThemeProvider theme={darkTheme}>
+          <MemoryRouter initialEntries={[route]}>
+            <Router />
+          </MemoryRouter>
+        </ThemeProvider>
       </QueryClientProvider>
     </RecoilRoot>,
   );

--- a/frontend/src/__test__/utils/type.ts
+++ b/frontend/src/__test__/utils/type.ts
@@ -1,0 +1,3 @@
+export type renderWithProvidersProps = {
+  route: string;
+};

--- a/frontend/src/components/FeedItem/index.tsx
+++ b/frontend/src/components/FeedItem/index.tsx
@@ -114,7 +114,7 @@ export const FeedItem = ({
       <Text size={14} color={themeContext.mainText}>
         {`${year}.${month}.${date} ${hours}:${minutes}`}
       </Text>
-      <MainText size={16} color={themeContext.onBackground} aria-label={`피드 내용`}>
+      <MainText size={16} color={themeContext.onBackground} aria-label="피드 내용">
         {description}
       </MainText>
       <CommentCount size={14} color={themeContext.mainText}>

--- a/frontend/src/components/FeedItem/index.tsx
+++ b/frontend/src/components/FeedItem/index.tsx
@@ -114,7 +114,7 @@ export const FeedItem = ({
       <Text size={14} color={themeContext.mainText}>
         {`${year}.${month}.${date} ${hours}:${minutes}`}
       </Text>
-      <MainText size={16} color={themeContext.onBackground}>
+      <MainText size={16} color={themeContext.onBackground} aria-label={`피드 내용`}>
         {description}
       </MainText>
       <CommentCount size={14} color={themeContext.mainText}>


### PR DESCRIPTION
resolve #204 

# 작업 현황
- 테스트 환경에도 Router 컴포넌트를 이용하도록 수정
  - Router 컴포넌트에서 BrowserRouter 분리 ([2ed4f8f](https://github.com/woowacourse-teams/2022-smody/pull/665/commits/2ed4f8fe894a65024de42872c87410f9ef9e3703))
  - renderWithProviders에서 Router 컴포넌트를 이용하도록 수정 ([2c21eea](https://github.com/woowacourse-teams/2022-smody/pull/665/commits/2c21eea030c62b6ae8a16944ec41deca86acdbe3))
- 피드 상세 보기 페이지 useGetFeedByID 훅 테스트 추가 ([1ee9239](https://github.com/woowacourse-teams/2022-smody/pull/665/commits/1ee9239dba1ad81fc7f298874476838fa8ca6dcc))

# 의논할 내용
피드 상세 보기 페이지에서 사용되는 아래의 훅들은 jsdom 환경에서 테스트가 불가능합니다.
- usePostComment(댓글 작성 훅)
- usePatchCommenets(댓글 수정 훅)
 
따라서 위 훅 들을 테스트하기 위해서는 jsdom이 아니라 실제 브라우저 환경에서 테스트를 진행해야 할 거 같습니다!
예를 들어 puppeteer를 사용하면 jest 환경에서 E2E 테스트를 진행할 수 있는 걸로 확인했습니다!
E2E 테스트 도입에 대해서도 이야기하면 좋을 거 같아요~