### PR TITLE
refactor:(be) 사이클 생성 로직 도메인 영역에서 구현하도록 변경

### DIFF
--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/Cycle.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/Cycle.java
@@ -96,12 +96,16 @@ public class Cycle {
         return progress.isInProgress(startTime, now);
     }
 
-    public boolean isSuccess() {
-        return this.progress.isSuccess();
+    public boolean isRetry(LocalDateTime startTime) {
+        return isSuccess() && isInDays(startTime);
     }
 
-    public boolean isInDays(LocalDateTime now) {
+    private boolean isInDays(LocalDateTime now) {
         return now.isBefore(this.getStartTime().plusDays(DAYS));
+    }
+
+    public boolean isSuccess() {
+        return this.progress.isSuccess();
     }
 
     public long calculateDeadLineToMillis(LocalDateTime searchTime) {

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/Cycle.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/Cycle.java
@@ -96,7 +96,17 @@ public class Cycle {
         return progress.isInProgress(startTime, now);
     }
 
-    public boolean isRetry(LocalDateTime startTime) {
+    public LocalDateTime calculateRetryStartTime(LocalDateTime retryStartTime) {
+        if (isInProgress(retryStartTime)) {
+            throw new BusinessException(ExceptionData.DUPLICATE_IN_PROGRESS_CHALLENGE);
+        }
+        if (isRetry(retryStartTime)) {
+            return startTime.plusDays(Cycle.DAYS);
+        }
+        return retryStartTime;
+    }
+
+    private boolean isRetry(LocalDateTime startTime) {
         return isSuccess() && isInDays(startTime);
     }
 

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/CycleDetailRepository.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/CycleDetailRepository.java
@@ -1,4 +1,4 @@
-package com.woowacourse.smody.cycle.repository;
+package com.woowacourse.smody.cycle.domain;
 
 import com.woowacourse.smody.cycle.domain.CycleDetail;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/CycleFactory.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/CycleFactory.java
@@ -1,0 +1,36 @@
+package com.woowacourse.smody.cycle.domain;
+
+import com.woowacourse.smody.challenge.domain.Challenge;
+import com.woowacourse.smody.exception.BusinessException;
+import com.woowacourse.smody.exception.ExceptionData;
+import com.woowacourse.smody.member.domain.Member;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public class CycleFactory {
+
+    public static Cycle create(Member member,
+                               Challenge challenge,
+                               LocalDateTime startTime,
+                               CycleRepository cycleRepository
+    ) {
+        Optional<Cycle> optionalCycle = cycleRepository.findRecent(member.getId(), challenge.getId());
+        if (optionalCycle.isPresent()) {
+            startTime = calculateNewStartTime(startTime, optionalCycle.get());
+        }
+        Cycle cycle = new Cycle(member, challenge, Progress.NOTHING, startTime);
+        cycleRepository.save(cycle);
+        return cycle;
+    }
+
+    private static LocalDateTime calculateNewStartTime(LocalDateTime startTime, Cycle cycle) {
+        if (cycle.isInProgress(startTime)) {
+            throw new BusinessException(ExceptionData.DUPLICATE_IN_PROGRESS_CHALLENGE);
+        }
+        if (cycle.isRetry(startTime)) {
+            return cycle.getStartTime().plusDays(Cycle.DAYS);
+        }
+        return startTime;
+    }
+}

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/CycleFactory.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/CycleFactory.java
@@ -4,17 +4,17 @@ import com.woowacourse.smody.challenge.domain.Challenge;
 import com.woowacourse.smody.exception.BusinessException;
 import com.woowacourse.smody.exception.ExceptionData;
 import com.woowacourse.smody.member.domain.Member;
+import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+@RequiredArgsConstructor
 public class CycleFactory {
 
-    public static Cycle create(Member member,
-                               Challenge challenge,
-                               LocalDateTime startTime,
-                               CycleRepository cycleRepository
-    ) {
+    private final CycleRepository cycleRepository;
+
+    public Cycle create(Member member, Challenge challenge, LocalDateTime startTime) {
         Optional<Cycle> optionalCycle = cycleRepository.findRecent(member.getId(), challenge.getId());
         if (optionalCycle.isPresent()) {
             startTime = calculateNewStartTime(startTime, optionalCycle.get());
@@ -24,7 +24,7 @@ public class CycleFactory {
         return cycle;
     }
 
-    private static LocalDateTime calculateNewStartTime(LocalDateTime startTime, Cycle cycle) {
+    private LocalDateTime calculateNewStartTime(LocalDateTime startTime, Cycle cycle) {
         if (cycle.isInProgress(startTime)) {
             throw new BusinessException(ExceptionData.DUPLICATE_IN_PROGRESS_CHALLENGE);
         }

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/CycleFactory.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/CycleFactory.java
@@ -17,20 +17,11 @@ public class CycleFactory {
     public Cycle create(Member member, Challenge challenge, LocalDateTime startTime) {
         Optional<Cycle> optionalCycle = cycleRepository.findRecent(member.getId(), challenge.getId());
         if (optionalCycle.isPresent()) {
-            startTime = calculateNewStartTime(startTime, optionalCycle.get());
+            Cycle cycle = optionalCycle.get();
+            startTime = cycle.calculateRetryStartTime(startTime);
         }
         Cycle cycle = new Cycle(member, challenge, Progress.NOTHING, startTime);
         cycleRepository.save(cycle);
         return cycle;
-    }
-
-    private LocalDateTime calculateNewStartTime(LocalDateTime startTime, Cycle cycle) {
-        if (cycle.isInProgress(startTime)) {
-            throw new BusinessException(ExceptionData.DUPLICATE_IN_PROGRESS_CHALLENGE);
-        }
-        if (cycle.isRetry(startTime)) {
-            return cycle.getStartTime().plusDays(Cycle.DAYS);
-        }
-        return startTime;
     }
 }

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/CycleRepository.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/CycleRepository.java
@@ -1,7 +1,8 @@
-package com.woowacourse.smody.cycle.repository;
+package com.woowacourse.smody.cycle.domain;
 
 import com.woowacourse.smody.challenge.domain.Challenge;
 import com.woowacourse.smody.cycle.domain.Cycle;
+import com.woowacourse.smody.cycle.repository.DynamicCycleRepository;
 import com.woowacourse.smody.member.domain.Member;
 import java.time.LocalDateTime;
 import java.util.List;

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/CycleRepository.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/CycleRepository.java
@@ -1,7 +1,6 @@
 package com.woowacourse.smody.cycle.domain;
 
 import com.woowacourse.smody.challenge.domain.Challenge;
-import com.woowacourse.smody.cycle.repository.DynamicCycleRepository;
 import com.woowacourse.smody.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -13,7 +12,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-public interface CycleRepository extends JpaRepository<Cycle, Long>, DynamicCycleRepository {
+public interface CycleRepository extends JpaRepository<Cycle, Long> {
 
     @Query("select c from Cycle c "
             + "join fetch c.challenge "

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/CycleRepository.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/domain/CycleRepository.java
@@ -1,18 +1,17 @@
 package com.woowacourse.smody.cycle.domain;
 
 import com.woowacourse.smody.challenge.domain.Challenge;
-import com.woowacourse.smody.cycle.domain.Cycle;
 import com.woowacourse.smody.cycle.repository.DynamicCycleRepository;
 import com.woowacourse.smody.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import javax.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import javax.persistence.LockModeType;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface CycleRepository extends JpaRepository<Cycle, Long>, DynamicCycleRepository {
 
@@ -36,10 +35,6 @@ public interface CycleRepository extends JpaRepository<Cycle, Long>, DynamicCycl
     Optional<Cycle> findRecent(@Param("memberId") Long memberId, @Param("challengeId") Long challengeId);
 
     List<Cycle> findByMember(Member member);
-
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("delete from Cycle c where c.member = :member")
-    void deleteByMember(@Param("member") Member member);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select c from Cycle c where c.id = :cycleId")

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/repository/DynamicCycleRepositoryImpl.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/repository/DynamicCycleRepositoryImpl.java
@@ -20,8 +20,10 @@ import com.woowacourse.smody.db_support.PagingParams;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
+@Repository
 public class DynamicCycleRepositoryImpl implements DynamicCycleRepository {
 
     private final JPAQueryFactory queryFactory;

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/service/CycleService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/service/CycleService.java
@@ -21,23 +21,33 @@ import com.woowacourse.smody.image.domain.Image;
 import com.woowacourse.smody.member.domain.Member;
 import com.woowacourse.smody.member.service.MemberService;
 
-import lombok.RequiredArgsConstructor;
-
 @Service
 @Transactional(readOnly = true)
-@RequiredArgsConstructor
 public class CycleService {
 
     private final CycleRepository cycleRepository;
     private final CycleDetailRepository cycleDetailRepository;
     private final MemberService memberService;
     private final ChallengeService challengeService;
+    private final CycleFactory cycleFactory;
+
+    public CycleService(CycleRepository cycleRepository,
+                        CycleDetailRepository cycleDetailRepository,
+                        MemberService memberService,
+                        ChallengeService challengeService) {
+        this.cycleRepository = cycleRepository;
+        this.cycleDetailRepository = cycleDetailRepository;
+        this.memberService = memberService;
+        this.challengeService = challengeService;
+        this.cycleFactory = new CycleFactory(cycleRepository);
+    }
+
 
     @Transactional
     public Cycle create(Long memberId, Long challengeId, LocalDateTime startTime) {
         Member member = memberService.search(memberId);
         Challenge challenge = challengeService.search(challengeId);
-        return CycleFactory.create(member, challenge, startTime, cycleRepository);
+        return cycleFactory.create(member, challenge, startTime);
     }
 
     @Transactional

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/service/CycleService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/service/CycleService.java
@@ -7,13 +7,14 @@ import java.util.List;
 import java.util.Optional;
 
 import com.woowacourse.smody.cycle.domain.*;
+import com.woowacourse.smody.cycle.repository.DynamicCycleRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.woowacourse.smody.challenge.domain.Challenge;
 import com.woowacourse.smody.challenge.domain.ChallengingRecord;
 import com.woowacourse.smody.challenge.service.ChallengeService;
-import com.woowacourse.smody.cycle.repository.CycleDetailRepository;
+import com.woowacourse.smody.cycle.domain.CycleDetailRepository;
 import com.woowacourse.smody.db_support.PagingParams;
 import com.woowacourse.smody.exception.BusinessException;
 import com.woowacourse.smody.exception.ExceptionData;
@@ -26,16 +27,19 @@ import com.woowacourse.smody.member.service.MemberService;
 public class CycleService {
 
     private final CycleRepository cycleRepository;
+    private final DynamicCycleRepository dynamicCycleRepository;
     private final CycleDetailRepository cycleDetailRepository;
     private final MemberService memberService;
     private final ChallengeService challengeService;
     private final CycleFactory cycleFactory;
 
     public CycleService(CycleRepository cycleRepository,
+                        DynamicCycleRepository dynamicCycleRepository,
                         CycleDetailRepository cycleDetailRepository,
                         MemberService memberService,
                         ChallengeService challengeService) {
         this.cycleRepository = cycleRepository;
+        this.dynamicCycleRepository = dynamicCycleRepository;
         this.cycleDetailRepository = cycleDetailRepository;
         this.memberService = memberService;
         this.challengeService = challengeService;
@@ -101,7 +105,7 @@ public class CycleService {
     }
 
     public List<Cycle> findAllByMemberAndFilter(Member member, PagingParams pagingParams) {
-        return cycleRepository.findAllByMemberAndFilter(member.getId(), pagingParams);
+        return dynamicCycleRepository.findAllByMemberAndFilter(member.getId(), pagingParams);
     }
 
     public List<Cycle> findInProgressByChallenges(LocalDateTime searchTime, List<Challenge> challenges) {
@@ -121,11 +125,11 @@ public class CycleService {
     public List<Cycle> findAllByMemberAndChallengeAndFilter(Long memberId,
                                                             Long challengeId,
                                                             PagingParams pagingParams) {
-        return cycleRepository.findAllByMemberAndChallengeAndFilter(memberId, challengeId, pagingParams);
+        return dynamicCycleRepository.findAllByMemberAndChallengeAndFilter(memberId, challengeId, pagingParams);
     }
 
     public List<ChallengingRecord> findAllChallengingRecordByMember(Member member) {
-        return cycleRepository.findAllChallengingRecordByMemberAfterTime(
+        return dynamicCycleRepository.findAllChallengingRecordByMemberAfterTime(
                 member.getId(),
                 LocalDateTime.now().minusDays(Cycle.DAYS)
         );

--- a/backend/smody/src/main/java/com/woowacourse/smody/cycle/service/CycleService.java
+++ b/backend/smody/src/main/java/com/woowacourse/smody/cycle/service/CycleService.java
@@ -6,17 +6,14 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import com.woowacourse.smody.cycle.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.woowacourse.smody.challenge.domain.Challenge;
 import com.woowacourse.smody.challenge.domain.ChallengingRecord;
 import com.woowacourse.smody.challenge.service.ChallengeService;
-import com.woowacourse.smody.cycle.domain.Cycle;
-import com.woowacourse.smody.cycle.domain.CycleDetail;
-import com.woowacourse.smody.cycle.domain.Progress;
 import com.woowacourse.smody.cycle.repository.CycleDetailRepository;
-import com.woowacourse.smody.cycle.repository.CycleRepository;
 import com.woowacourse.smody.db_support.PagingParams;
 import com.woowacourse.smody.exception.BusinessException;
 import com.woowacourse.smody.exception.ExceptionData;
@@ -40,25 +37,7 @@ public class CycleService {
     public Cycle create(Long memberId, Long challengeId, LocalDateTime startTime) {
         Member member = memberService.search(memberId);
         Challenge challenge = challengeService.search(challengeId);
-        Optional<Cycle> optionalCycle = cycleRepository.findRecent(member.getId(), challenge.getId());
-        if (optionalCycle.isPresent()) {
-            startTime = calculateNewStartTime(startTime, optionalCycle.get());
-        }
-        return cycleRepository.save(new Cycle(member, challenge, Progress.NOTHING, startTime));
-    }
-
-    private LocalDateTime calculateNewStartTime(LocalDateTime startTime, Cycle cycle) {
-        if (cycle.isInProgress(startTime)) {
-            throw new BusinessException(ExceptionData.DUPLICATE_IN_PROGRESS_CHALLENGE);
-        }
-        if (isRetry(startTime, cycle)) {
-            return cycle.getStartTime().plusDays(Cycle.DAYS);
-        }
-        return startTime;
-    }
-
-    private boolean isRetry(final LocalDateTime startTime, final Cycle cycle) {
-        return cycle.isSuccess() && cycle.isInDays(startTime);
+        return CycleFactory.create(member, challenge, startTime, cycleRepository);
     }
 
     @Transactional

--- a/backend/smody/src/test/java/com/woowacourse/smody/cycle/domain/CycleFactoryTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/cycle/domain/CycleFactoryTest.java
@@ -1,0 +1,112 @@
+package com.woowacourse.smody.cycle.domain;
+
+import com.woowacourse.smody.challenge.domain.Challenge;
+import com.woowacourse.smody.exception.BusinessException;
+import com.woowacourse.smody.exception.ExceptionData;
+import com.woowacourse.smody.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static com.woowacourse.smody.support.ResourceFixture.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@SuppressWarnings("NonAsciiCharacters")
+@ExtendWith(MockitoExtension.class)
+class CycleFactoryTest {
+
+    @Mock
+    private Member member;
+
+    @Mock
+    private Challenge challenge;
+
+    @Mock
+    private CycleRepository cycleRepository;
+
+    @DisplayName("사이클을 생성한다.")
+    @Test
+    void create() {
+        // given
+        given(member.getId()).willReturn(조조그린_ID);
+        given(challenge.getId()).willReturn(미라클_모닝_ID);
+        given(cycleRepository.findRecent(조조그린_ID, 미라클_모닝_ID))
+                .willReturn(Optional.empty());
+
+        LocalDateTime startTime = LocalDateTime.now();
+
+        // when
+        Cycle actual = CycleFactory.create(member, challenge, startTime, cycleRepository);
+
+        // then
+        assertThat(actual.getStartTime()).isEqualTo(startTime);
+    }
+
+    @DisplayName("동일한 첼린지에 진행중인 사이클이 존재하는 경우 사이클을 생성할 때 예외를 발생시킨다.")
+    @Test
+    void create_duplicateInProgressChallenge() {
+        // given
+        given(member.getId()).willReturn(조조그린_ID);
+        given(challenge.getId()).willReturn(미라클_모닝_ID);
+        given(cycleRepository.findRecent(조조그린_ID, 미라클_모닝_ID))
+                .willReturn(
+                        Optional.of(new Cycle(member, challenge, Progress.FIRST, LocalDateTime.now().minusDays(1)))
+                );
+
+        LocalDateTime startTime = LocalDateTime.now();
+
+        // when then
+        assertThatThrownBy(() -> CycleFactory.create(member, challenge, startTime, cycleRepository))
+                .isInstanceOf(BusinessException.class)
+                .extracting("exceptionData")
+                .isEqualTo(ExceptionData.DUPLICATE_IN_PROGRESS_CHALLENGE);
+    }
+
+    @DisplayName("현재 시각 기준 24시간이 이후가 지난 시작시간을 가진 사이클을 생성할 때 예외를 발생시킨다.")
+    @Test
+    void create_overOneDay() {
+        // given
+        given(member.getId()).willReturn(조조그린_ID);
+        given(challenge.getId()).willReturn(미라클_모닝_ID);
+        given(cycleRepository.findRecent(조조그린_ID, 미라클_모닝_ID))
+                .willReturn(Optional.empty());
+
+        LocalDateTime startTime = LocalDateTime.now()
+                .plusDays(1)
+                .plusSeconds(1);
+
+        // when then
+        assertThatThrownBy(() -> CycleFactory.create(member, challenge, startTime, cycleRepository))
+                .isInstanceOf(BusinessException.class)
+                .extracting("exceptionData")
+                .isEqualTo(ExceptionData.INVALID_START_TIME);
+    }
+
+    @DisplayName("오늘 성공한 챌린지로 다시 사이클을 생성한 경우 사이클을 내일 날짜로 생성한다.")
+    @Test
+    void create_alreadySuccessChallenge() {
+        // given
+        given(member.getId()).willReturn(조조그린_ID);
+        given(challenge.getId()).willReturn(미라클_모닝_ID);
+        LocalDateTime beforeStartTime = LocalDateTime.now().minusDays(2);
+        given(cycleRepository.findRecent(조조그린_ID, 미라클_모닝_ID))
+                .willReturn(
+                        Optional.of(new Cycle(member, challenge, Progress.SUCCESS, beforeStartTime))
+                );
+
+        LocalDateTime startTime = LocalDateTime.now();
+
+        // when
+        Cycle actual = CycleFactory.create(member, challenge, startTime, cycleRepository);
+
+        // then
+        assertThat(actual.getStartTime()).isEqualTo(beforeStartTime.plusDays(3));
+    }
+}

--- a/backend/smody/src/test/java/com/woowacourse/smody/cycle/domain/CycleFactoryTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/cycle/domain/CycleFactoryTest.java
@@ -69,7 +69,7 @@ class CycleFactoryTest {
                 .isEqualTo(ExceptionData.DUPLICATE_IN_PROGRESS_CHALLENGE);
     }
 
-    @DisplayName("현재 시각 기준 24시간이 이후가 지난 시작시간을 가진 사이클을 생성할 때 예외를 발생시킨다.")
+    @DisplayName("현재 시각 기준 24시간이 지난 시작시간을 가진 사이클을 생성할 때 예외를 발생시킨다.")
     @Test
     void create_overOneDay() {
         // given

--- a/backend/smody/src/test/java/com/woowacourse/smody/cycle/repository/CycleRepositoryTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/cycle/repository/CycleRepositoryTest.java
@@ -25,6 +25,8 @@ class CycleRepositoryTest extends RepositoryTest {
 
     @Autowired
     private CycleRepository cycleRepository;
+    @Autowired
+    private DynamicCycleRepository dynamicCycleRepository;
 
     @Autowired
     private ResourceFixture fixture;
@@ -84,7 +86,7 @@ class CycleRepositoryTest extends RepositoryTest {
         fixture.사이클_생성_SUCCESS(더즈_ID, 오늘의_운동_ID, now.plusSeconds(1L));
 
         // when
-        List<ChallengingRecord> actual = cycleRepository.findAllChallengingRecordByMemberAfterTime(조조그린_ID,
+        List<ChallengingRecord> actual = dynamicCycleRepository.findAllChallengingRecordByMemberAfterTime(조조그린_ID,
                 now.minusDays(3));
 
         for (ChallengingRecord challengingRecord : actual) {

--- a/backend/smody/src/test/java/com/woowacourse/smody/cycle/repository/CycleRepositoryTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/cycle/repository/CycleRepositoryTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.woowacourse.smody.challenge.domain.ChallengingRecord;
 import com.woowacourse.smody.cycle.domain.Cycle;
 import com.woowacourse.smody.cycle.domain.CycleDetail;
+import com.woowacourse.smody.cycle.domain.CycleRepository;
 import com.woowacourse.smody.support.RepositoryTest;
 import com.woowacourse.smody.support.ResourceFixture;
 import java.time.LocalDateTime;

--- a/backend/smody/src/test/java/com/woowacourse/smody/member/service/MemberApiServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/member/service/MemberApiServiceTest.java
@@ -12,7 +12,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.woowacourse.smody.auth.dto.TokenPayload;
 import com.woowacourse.smody.cycle.domain.Cycle;
-import com.woowacourse.smody.cycle.repository.CycleRepository;
+import com.woowacourse.smody.cycle.domain.CycleRepository;
 import com.woowacourse.smody.db_support.PagingParams;
 import com.woowacourse.smody.exception.BusinessException;
 import com.woowacourse.smody.member.domain.Member;

--- a/backend/smody/src/test/java/com/woowacourse/smody/member/service/MemberServiceTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/member/service/MemberServiceTest.java
@@ -15,7 +15,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.woowacourse.smody.comment.repository.CommentRepository;
 import com.woowacourse.smody.cycle.domain.Cycle;
-import com.woowacourse.smody.cycle.repository.CycleRepository;
+import com.woowacourse.smody.cycle.domain.CycleRepository;
 import com.woowacourse.smody.db_support.PagingParams;
 import com.woowacourse.smody.exception.BusinessException;
 import com.woowacourse.smody.exception.ExceptionData;

--- a/backend/smody/src/test/java/com/woowacourse/smody/support/RepositoryTest.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/support/RepositoryTest.java
@@ -1,5 +1,7 @@
 package com.woowacourse.smody.support;
 
+import com.woowacourse.smody.cycle.repository.DynamicCycleRepository;
+import com.woowacourse.smody.cycle.repository.DynamicCycleRepositoryImpl;
 import com.woowacourse.smody.support.config.QueryFactoryTestConfig;
 import com.woowacourse.smody.support.isoloation.SmodyDatabaseManager;
 import org.junit.jupiter.api.AfterEach;
@@ -9,7 +11,12 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest(showSql = false)
-@Import({ResourceFixture.class, SmodyDatabaseManager.class, QueryFactoryTestConfig.class})
+@Import({
+        ResourceFixture.class,
+        SmodyDatabaseManager.class,
+        QueryFactoryTestConfig.class,
+        DynamicCycleRepositoryImpl.class
+})
 public class RepositoryTest {
 
     @Autowired

--- a/backend/smody/src/test/java/com/woowacourse/smody/support/ResourceFixture.java
+++ b/backend/smody/src/test/java/com/woowacourse/smody/support/ResourceFixture.java
@@ -7,7 +7,7 @@ import com.woowacourse.smody.comment.repository.CommentRepository;
 import com.woowacourse.smody.cycle.domain.Cycle;
 import com.woowacourse.smody.cycle.domain.CycleDetail;
 import com.woowacourse.smody.cycle.domain.Progress;
-import com.woowacourse.smody.cycle.repository.CycleRepository;
+import com.woowacourse.smody.cycle.domain.CycleRepository;
 import com.woowacourse.smody.image.domain.Image;
 import com.woowacourse.smody.member.domain.Member;
 import com.woowacourse.smody.member.repository.MemberRepository;


### PR DESCRIPTION
오랜만에 PR 드립니다! 복잡한건 아니고 최근에 DDD를 공부하는 김에 간단한 변경 사항 한 번 적용해 보았습니다. 목적은 도메인 로직을 도메인 영역으로 밀어넣어 도메인 응집도를 높이기 위함입니다.

## 이전의 사이클 생성 로직
``` java
    @Transactional
    public Cycle create(Long memberId, Long challengeId, LocalDateTime startTime) {
        Member member = memberService.search(memberId);
        Challenge challenge = challengeService.search(challengeId);
        Optional<Cycle> optionalCycle = cycleRepository.findRecent(member.getId(), challenge.getId());
        if (optionalCycle.isPresent()) {
            startTime = calculateNewStartTime(startTime, optionalCycle.get());
        }
        return cycleRepository.save(new Cycle(member, challenge, Progress.NOTHING, startTime));
    }

    private LocalDateTime calculateNewStartTime(LocalDateTime startTime, Cycle cycle) {
        if (cycle.isInProgress(startTime)) {
            throw new BusinessException(ExceptionData.DUPLICATE_IN_PROGRESS_CHALLENGE);
        }
        if (isRetry(startTime, cycle)) {
            return cycle.getStartTime().plusDays(Cycle.DAYS);
        }
        return startTime;
    }

    private boolean isRetry(final LocalDateTime startTime, final Cycle cycle) {
        return cycle.isSuccess() && cycle.isInDays(startTime);
    }
```
사이클을 생성하는 로직은 도메인 로직입니다. 하지만 다른 사이클의 존재 유무 때문에 생성할 수 있냐 없냐가 결정되는 규칙 때문에 리포지터리를 이용하고자  애플리케이션 영역(서비스 레이어)에 도메인 로직이 삐져나와 있습니다. 사이클 생성에 대한 업무 규칙이 여러 레이어(패키지)에 분산되어 있어 응집도가 떨어지고 사이클 생성 로직이 변경된다면 도메인 패키지도, 서비스 패키지도 수정해야 하는 불편함이 있습니다.

## 도메인 영역에서 팩토리를 통해 사이클 생성
``` java
    @Transactional
    public Cycle create(Long memberId, Long challengeId, LocalDateTime startTime) {
        Member member = memberService.search(memberId);
        Challenge challenge = challengeService.search(challengeId);
        return CycleFactory.create(member, challenge, startTime, cycleRepository);
    }
```
사이클을 생성하는 팩토리 클래스에 사이클 생성 책임을 위임했습니다. `CycleFactory`는 도메인 영역에 위치하고 있기에 도메인 영역에 해당합니다. 서비스 레이어 흩어져 있던 사이클 도메인 규칙을 도메인 영역으로 넣어 응집도를 높였습니다. 사이클 생성에 관해 변경이 생긴다면 도메인 영역(패키지)만 수정하면 됩니다.

## 리포지터리를 파라미터로 전달?
사이클 생성에 관한 업무 규칙을 구현하기 위해선 사이클 저장소에 접근할 필요가 있었기에 `CycleRepository`가 필요했습니다. 처음엔 `CycleFactory`를 빈으로 만들어 리포지터리를 DI 받을까 생각도 했었습니다. 하지만 그렇게되면 도메인 영역인 `CycleFactory`를 테스트 하기 위해 스프링 컨테이너를 띄워야 했기에 인터페이스를 파라미터로 전달 받는 쪽으로 구현했습니다. 

## CycleRepository 패키지 
원래 저희 팀 컨벤션으론 리포지터리 인터페이스의 위치는 `repository` 패키지에 위치합니다. 하지만 점진적으로 리포지터리 인터페이스들을 도메인 영역에 넣고 싶다는 생각을 하고 있습니다. 도메인 저장소인 리포지터리는 도메인 패키지로, 그것을 구현한 클래스는 `repository` 패키지에 위치시키는 것입니다. 우선 `Cycle` 패키지에선 리포지터리 인터페이스를 도메인 영역에 위치시켜 놓았습니다.